### PR TITLE
Add canvas background color picker setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+iPad-only art reference board app built with Swift/SwiftUI. Users organize images, GIFs, videos, and text notes on an infinite canvas. Offline-first, no external dependencies — only native Apple frameworks.
+
+**Bundle ID:** `AxI.SuperCoolArtReferenceTool1`
+**Deployment Target:** iPadOS 26.1
+
+## Build & Run
+
+```bash
+# Build for simulator
+xcodebuild -project SuperCoolArtReferenceTool.xcodeproj \
+  -scheme SuperCoolArtReferenceTool \
+  -destination 'platform=iOS Simulator,name=iPad Air' \
+  -configuration Debug build
+
+# Or open in Xcode
+open SuperCoolArtReferenceTool.xcodeproj
+```
+
+No package managers (no SPM, CocoaPods, or Carthage). No test targets currently exist.
+
+## Architecture
+
+### Dev Role System
+
+Development is split between two roles. **Ask the user which role before starting work.**
+
+- **Dev A (Frontend/Canvas):** Canvas rendering, gestures, SwiftUI views, UI components. Works in `Features/`, `DesignSystem/`, `UIComponents/`. Updates `architecture-frontend.md`.
+- **Dev B (Data/Persistence):** Data models, storage, persistence, services. Works in `Models/`, `Persistence/`, `Services/`. Updates `architecture-backend.md`.
+
+Avoid modifying the other role's systems unless explicitly instructed. Documentation is split to prevent merge conflicts.
+
+### Key Data Flow
+
+```
+SuperCoolArtReferenceToolApp → RootView → FilePickerView (landing) → ContentView → BoardCanvasView
+                                                                         ↕
+                                                                   LocalBoardStore (actor, tile-indexed spatial store)
+```
+
+### Core Files
+
+| File | Role |
+|------|------|
+| `Features/BoardCanvas/BoardCanvasView.swift` | Infinite canvas: pan/zoom gestures, image rendering, viewport culling |
+| `Persistence/CanvasModels.swift` | Core types: `CMCanvasElement`, `CMWorldRect`, `CMTileKey`, `CMElementHeader` |
+| `Persistence/LocalBoardStore.swift` | In-memory tile-indexed store (actor), spatial queries, z-order management |
+| `Persistence/LocalCanvasService.swift` | Service layer wrapping LocalBoardStore |
+| `App/BoardArchiver.swift` | Import/export `.refboard` packages (JSON manifest + assets/) |
+| `App/ContentView.swift` | Main canvas container, toolbar layout, export/import UI |
+| `Features/HUD/CanvasToolbar.swift` | Left/right toolbar with tool selection, undo/redo |
+| `Features/FilePicker/FilePickerView.swift` | Landing screen with drag-and-drop/browse for initial file import |
+| `DesignSystem/Colors.swift` | Color palette: primary (#191919), secondary (#535353), tertiary (#86B8FE), text (#FFFFFF) |
+
+### Coordinate Systems
+
+- **Frontend (Dev A):** `CGFloat`, `CGPoint`, `CGRect` — screen-to-world: `(screenPoint - offset) / scale`
+- **Backend (Dev B):** `SIMD2<Double>`, `CMWorldRect` — tile-based spatial indexing (`CMTileKey`, tile size 1024)
+- Integration requires conversion between these two systems.
+
+### Canvas Constants
+
+- Zoom range: 0.05x – 8.0x
+- Grid spacing: 128 world units
+- Tile cache capacity: 256 tiles
+- Image size range: 64 – 512 world units
+- Gesture minimum distance: 8pt
+
+## Documentation
+
+Three docs describe the system — read them before major changes:
+
+- `context.md` — Product goals, dev roles, MVP scope (shared, high-level)
+- `architecture-frontend.md` — Canvas, gestures, UI implementation (Dev A owns)
+- `architecture-backend.md` — Data models, persistence, export format (Dev B owns)
+
+Document only finalized implementations, not speculative architecture.
+
+## Known Issues
+
+- `.refboard` UTType declared in code but not in Info.plist — produces runtime warning. See `App/InfoPlist_Refboard_Additions.md`.
+- File loading logic duplicated between `BoardCanvasView.swift` and `InsertFileControl.swift`.
+- Pointer and group tools in toolbar are not yet connected to canvas behavior.

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     // Settings
     @State private var showGrid = true
     @State private var toolbarSide: ToolbarSide = .left
+    @State private var canvasColor: Color = .white
     
     @State private var snapshotToken: UUID? = nil
     @State private var elementsToLoad: [CMCanvasElement]? = nil
@@ -34,6 +35,7 @@ struct ContentView: View {
             BoardCanvasView(
                 externalInsertURLs: $urlsToInsert,
                 showGrid: $showGrid,
+                canvasColor: $canvasColor,
                 snapshotTrigger: $snapshotToken,
                 loadElements: $elementsToLoad,
                 onInsertURLs: { _ in },
@@ -109,7 +111,7 @@ struct ContentView: View {
             importerMode = nil
         }
         .sheet(isPresented: $showingSettings) {
-            CanvasSettingsView(showGrid: $showGrid, toolbarSide: $toolbarSide)
+            CanvasSettingsView(showGrid: $showGrid, toolbarSide: $toolbarSide, canvasColor: $canvasColor)
         }
         .onAppear {
             if !initialURLs.isEmpty {

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -20,6 +20,7 @@ struct BoardCanvasView: View {
 
     // Grid options
     @Binding private var showGrid: Bool
+    @Binding private var canvasColor: Color
     @State private var gridSpacingWorld: CGFloat = 128.0
     @Environment(\.displayScale) private var displayScale
 
@@ -52,11 +53,12 @@ struct BoardCanvasView: View {
     private let onSnapshot: (([CMCanvasElement]) -> Void)?
     @Binding private var elementsToLoad: [CMCanvasElement]?
 
-    init(externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement]) -> Void)? = nil) {
+    init(externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), canvasColor: Binding<Color> = .constant(.white), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement]) -> Void)? = nil) {
         let store = LocalBoardStore()
         self._canvasStore = State(initialValue: store)
         self._externalInsertURLs = externalInsertURLs
         self._showGrid = showGrid
+        self._canvasColor = canvasColor
         self.onInsertURLs = onInsertURLs
         self._snapshotTrigger = snapshotTrigger
         self._elementsToLoad = loadElements
@@ -125,6 +127,7 @@ struct BoardCanvasView: View {
             .onDrop(of: allowedDropTypes, delegate: CanvasDropDelegate(allowedTypes: allowedDropTypes) { point, urls in
                 insertImages(atScreenPoint: point, urls: urls)
             })
+            .background(canvasColor)
             .border(Color.gray.opacity(0.4), width: 1)
             .onAppear {
                 canvasSize = geo.size

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -127,7 +127,9 @@ struct BoardCanvasView: View {
             .onDrop(of: allowedDropTypes, delegate: CanvasDropDelegate(allowedTypes: allowedDropTypes) { point, urls in
                 insertImages(atScreenPoint: point, urls: urls)
             })
-            .background(canvasColor)
+            .background {
+                canvasColor.ignoresSafeArea()
+            }
             .border(Color.gray.opacity(0.4), width: 1)
             .onAppear {
                 canvasSize = geo.size

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
@@ -27,7 +27,6 @@ struct CanvasSettingsView: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .fill(canvasColor)
                                 .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                                .frame(width: 48, height: 28)
                                 .allowsHitTesting(false)
                             ColorPicker("", selection: $canvasColor, supportsOpacity: false)
                                 .labelsHidden()
@@ -35,7 +34,7 @@ struct CanvasSettingsView: View {
                                 .opacity(0.015)
                         }
                         .frame(width: 48, height: 28)
-                        .clipped()
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                     }
 
                     Toggle("Show Grid", isOn: $showGrid)

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
@@ -34,7 +34,7 @@ struct CanvasSettingsView: View {
                                 .opacity(0.015)
                         }
                         .frame(width: 48, height: 28)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .contentShape(RoundedRectangle(cornerRadius: 8))
                     }
 
                     Toggle("Show Grid", isOn: $showGrid)

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
@@ -13,15 +13,35 @@ struct CanvasSettingsView: View {
     
     @Binding var showGrid: Bool
     @Binding var toolbarSide: ToolbarSide
-    
+    @Binding var canvasColor: Color
+
     var body: some View {
         NavigationView {
             List {
                 Section("Canvas") {
+                    HStack {
+                        Text("Canvas Color")
+                            .foregroundStyle(DesignSystem.Colors.text)
+                        Spacer()
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(canvasColor)
+                                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                                .frame(width: 48, height: 28)
+                                .allowsHitTesting(false)
+                            ColorPicker("", selection: $canvasColor, supportsOpacity: false)
+                                .labelsHidden()
+                                .scaleEffect(CGSize(width: 2.0, height: 2.0))
+                                .opacity(0.015)
+                        }
+                        .frame(width: 48, height: 28)
+                        .clipped()
+                    }
+
                     Toggle("Show Grid", isOn: $showGrid)
                         .tint(DesignSystem.Colors.tertiary)
                         .foregroundStyle(DesignSystem.Colors.text)
-                    
+
                     HStack {
                         Text("Toolbar Position")
                             .foregroundStyle(DesignSystem.Colors.text)
@@ -76,6 +96,7 @@ enum ToolbarSide: String, Codable {
 #Preview {
     @Previewable @State var showGrid = true
     @Previewable @State var toolbarSide = ToolbarSide.left
-    
-    CanvasSettingsView(showGrid: $showGrid, toolbarSide: $toolbarSide)
+    @Previewable @State var canvasColor = Color.white
+
+    CanvasSettingsView(showGrid: $showGrid, toolbarSide: $toolbarSide, canvasColor: $canvasColor)
 }

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -308,7 +308,7 @@ A standalone settings button positioned dynamically at the bottom corner of the 
    - Binding: `@Binding var canvasColor: Color`
    - Connected to `BoardCanvasView.canvasColor` binding, applied as `.background(canvasColor)` on the canvas ZStack
    - Custom pill-shaped UI: a `RoundedRectangle` (48×28pt) filled with the current color, with an invisible `ColorPicker` scaled on top (`.opacity(0.015)`, `.scaleEffect(2.0)`)
-   - Hit area constrained to pill shape via `.clipShape(RoundedRectangle)`, pill set to `.allowsHitTesting(false)` so taps pass through to the picker
+   - Pill set to `.allowsHitTesting(false)` so taps pass through to the picker; hit area constrained to pill shape via `.contentShape(RoundedRectangle)` on the container
    - `supportsOpacity: false` — solid colors only
    - Default: `.white`
 

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -296,6 +296,7 @@ A standalone settings button positioned dynamically at the bottom corner of the 
 - **File:** `CanvasSettingsView.swift`
 - Navigation-based settings interface with full dark theme styling
 - **Functional Settings:**
+  - **Canvas Color Picker** - Changes the canvas background color via a custom pill-shaped color swatch that opens the system color picker
   - **Show Grid Toggle** - Controls canvas grid visibility via binding to `BoardCanvasView`
   - **Toolbar Position Picker** - Switches toolbar and settings button between left/right side
 - "Done" button styled with tertiary color to dismiss
@@ -303,13 +304,21 @@ A standalone settings button positioned dynamically at the bottom corner of the 
 
 **Settings Functionality:**
 
-1. **Grid Toggle:**
+1. **Canvas Color:**
+   - Binding: `@Binding var canvasColor: Color`
+   - Connected to `BoardCanvasView.canvasColor` binding, applied as `.background(canvasColor)` on the canvas ZStack
+   - Custom pill-shaped UI: a `RoundedRectangle` (48×28pt) filled with the current color, with an invisible `ColorPicker` scaled on top (`.opacity(0.015)`, `.scaleEffect(2.0)`)
+   - Hit area constrained to pill shape via `.clipShape(RoundedRectangle)`, pill set to `.allowsHitTesting(false)` so taps pass through to the picker
+   - `supportsOpacity: false` — solid colors only
+   - Default: `.white`
+
+2. **Grid Toggle:**
    - Binding: `@Binding var showGrid: Bool`
    - Connected to `BoardCanvasView.showGrid` binding
    - Instantly shows/hides grid lines on canvas
    - Default: `true`
 
-2. **Toolbar Position:**
+3. **Toolbar Position:**
    - Enum: `ToolbarSide` (`.left` or `.right`)
    - Controls position of both `CanvasToolbar` and `CanvasSettingsButton`
    - `ContentView` uses conditional layout (`leftSideLayout` or `rightSideLayout`)


### PR DESCRIPTION
## Summary
- Adds a canvas color setting to the settings menu with a custom pill-shaped color swatch
- Tapping the pill opens the system color picker (solid colors only, no opacity)
- Selected color is applied as the canvas background in `BoardCanvasView`
- Default canvas color is white

## Test plan
- [ ] Open settings, verify the canvas color pill displays correctly
- [ ] Tap the pill, verify the system color picker appears
- [ ] Select a color, verify the canvas background updates immediately
- [ ] Verify tapping outside the pill does not trigger the color picker

🤖 Generated with [Claude Code](https://claude.ai/code)