### PR TITLE
Add group tool with marquee select, group move/resize

### DIFF
--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -33,6 +33,8 @@ struct ContentView: View {
     @State private var redoTrigger: UUID?
 
     @State private var importerMode: ImporterMode? = nil
+    /// Latched copy so the result handler can read it even after the binding clears importerMode
+    @State private var lastImporterMode: ImporterMode? = nil
     private enum ImporterMode { case images, board }
 
     var body: some View {
@@ -71,6 +73,7 @@ struct ContentView: View {
 
                 Button("Import") {
                     importerMode = .board
+                    lastImporterMode = .board
                     print("[UI] Import Board tapped")
                 }
                 .buttonStyle(.bordered)
@@ -93,12 +96,12 @@ struct ContentView: View {
         .fileImporter(
             isPresented: Binding(
                 get: { importerMode != nil },
-                set: { _ in /* keep mode until handler runs */ }
+                set: { newValue in if !newValue { importerMode = nil } }
             ),
             allowedContentTypes: (importerMode == .images) ? [.image, .gif] : [.refboard, .package, .folder],
             allowsMultipleSelection: importerMode == .images
         ) { result in
-            let currentMode = importerMode
+            let currentMode = lastImporterMode
             print("[Importer] Unified fileImporter fired (mode: \(String(describing: currentMode)))")
             switch result {
             case .success(let urls):
@@ -149,6 +152,7 @@ struct ContentView: View {
                     onAddItem: {
                         print("[UI] Add Item tapped")
                         importerMode = .images
+                        lastImporterMode = .images
                     }
                 )
                 .padding(.leading, 16)
@@ -185,6 +189,7 @@ struct ContentView: View {
                     onAddItem: {
                         print("[UI] Add Item tapped")
                         importerMode = .images
+                        lastImporterMode = .images
                     }
                 )
                 .padding(.trailing, 16)

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -34,6 +34,7 @@ struct BoardCanvasView: View {
     // Backend store for tile-based culling
     @State private var canvasStore: LocalBoardStore
     @State private var refreshTask: Task<Void, Never>? = nil
+    @State private var storeMutationTask: Task<Void, Never>? = nil
 
     // Drop/import types (images and GIFs only)
     private let allowedDropTypes: [UTType] = [.image, .gif]
@@ -130,10 +131,26 @@ struct BoardCanvasView: View {
                 ForEach(visibleImages) { item in
                     let isSelected = selection.selectedIDs.contains(item.id)
                     let isBeingResized = selection.isResizing && selection.resizeElementID == item.id
-                    let liveRect = isBeingResized ? (selection.resizeCurrentRect ?? item.worldRect) : item.worldRect
+                    let isBeingGroupResized = selection.isGroupResizing && isSelected
+
+                    let liveRect: CGRect = {
+                        if isBeingGroupResized,
+                           let startRects = selection.groupResizeStartRects,
+                           let originalRect = startRects[item.id],
+                           let bboxStart = selection.groupResizeBBoxStart,
+                           let bboxCurrent = selection.groupResizeBBoxCurrent {
+                            return scaledRect(original: originalRect, bboxStart: bboxStart, bboxCurrent: bboxCurrent)
+                        } else if isBeingResized {
+                            return selection.resizeCurrentRect ?? item.worldRect
+                        } else {
+                            return item.worldRect
+                        }
+                    }()
 
                     let liveDX = (isSelected && selection.isDragging) ? selection.dragOffset.width * scale : 0
                     let liveDY = (isSelected && selection.isDragging) ? selection.dragOffset.height * scale : 0
+
+                    let multiSelected = selection.selectedIDs.count > 1
 
                     let maxDimensionPoints = max(liveRect.width * scale, liveRect.height * scale)
                     let requestedPixelSize = FileImageView.bucketedMaxPixelSize(maxDimensionPoints * displayScale)
@@ -142,14 +159,51 @@ struct BoardCanvasView: View {
                         .frame(width: liveRect.width * scale,
                                height: liveRect.height * scale)
                         .overlay {
-                            if isSelected {
+                            if isSelected && !multiSelected {
                                 SelectionOverlay()
+                            } else if isSelected && multiSelected {
+                                // Light border only for individual items in a multi-select
+                                Rectangle()
+                                    .strokeBorder(DesignSystem.Colors.tertiary.opacity(0.5), lineWidth: 1)
                             }
                         }
                         .position(x: (liveRect.midX * scale) + offset.width + liveDX,
                                   y: (liveRect.midY * scale) + offset.height + liveDY)
                         .shadow(radius: isInteracting ? 0 : 1)
                         .zIndex(Double(item.zIndex))
+                }
+
+                // Marquee selection rectangle
+                if selection.isMarqueeing, let worldRect = selection.marqueeWorldRect {
+                    let screenRect = CGRect(
+                        x: worldRect.origin.x * scale + offset.width,
+                        y: worldRect.origin.y * scale + offset.height,
+                        width: worldRect.width * scale,
+                        height: worldRect.height * scale
+                    )
+                    MarqueeOverlayView(screenRect: screenRect)
+                        .allowsHitTesting(false)
+                        .zIndex(Double(Int.max - 1))
+                }
+
+                // Group bounding box with resize handles
+                if selection.selectedIDs.count > 1, !selection.isDragging {
+                    let bbox: CGRect? = selection.isGroupResizing
+                        ? (selection.groupResizeBBoxCurrent ?? groupBoundingBox())
+                        : groupBoundingBox()
+                    if let bbox {
+                        let screenRect = CGRect(
+                            x: bbox.origin.x * scale + offset.width,
+                            y: bbox.origin.y * scale + offset.height,
+                            width: bbox.width * scale,
+                            height: bbox.height * scale
+                        )
+                        GroupSelectionOverlay()
+                            .frame(width: screenRect.width, height: screenRect.height)
+                            .position(x: screenRect.midX, y: screenRect.midY)
+                            .allowsHitTesting(false)
+                            .zIndex(Double(Int.max))
+                    }
                 }
             }
             .onDrop(of: allowedDropTypes, delegate: CanvasDropDelegate(allowedTypes: allowedDropTypes) { point, urls in
@@ -219,11 +273,22 @@ struct BoardCanvasView: View {
                             // First event — check for handle hit before tool behavior
                             dragStartOffset = offset
 
-                            if let (handle, item) = hitTestHandle(screenPoint: value.startLocation) {
-                                // Resize mode
-                                selection.resizeHandle = handle
-                                selection.resizeStartRect = item.worldRect
-                                selection.resizeElementID = item.id
+                            if let hitResult = hitTestHandle(screenPoint: value.startLocation) {
+                                switch hitResult {
+                                case .singleItem(let handle, let item):
+                                    selection.resizeHandle = handle
+                                    selection.resizeStartRect = item.worldRect
+                                    selection.resizeElementID = item.id
+                                case .group(let handle, let bbox):
+                                    var startRects: [UUID: CGRect] = [:]
+                                    for img in placedImages where selection.selectedIDs.contains(img.id) {
+                                        startRects[img.id] = img.worldRect
+                                    }
+                                    selection.groupResizeStartRects = startRects
+                                    selection.groupResizeBBoxStart = bbox
+                                    selection.groupResizeBBoxCurrent = bbox
+                                    selection.resizeHandle = handle
+                                }
                                 currentDragMode = .resizeItem
                                 applyDrag(value: value, mode: .resizeItem)
                                 return
@@ -235,6 +300,8 @@ struct BoardCanvasView: View {
                             let behavior = toolBehavior(for: activeTool)
                             let store = canvasStore
                             let sel = selection
+                            // Set sentinel to prevent re-entry while awaiting
+                            currentDragMode = DragMode.none
                             Task { @MainActor in
                                 let mode = await behavior.dragBegan(
                                     worldStart: worldStart,
@@ -242,6 +309,10 @@ struct BoardCanvasView: View {
                                     selection: sel
                                 )
                                 currentDragMode = mode
+                                if mode == .marqueeSelect {
+                                    selection.marqueeStartWorld = worldStart
+                                    selection.marqueeCurrentWorld = worldStart
+                                }
                                 applyDrag(value: value, mode: mode)
                             }
                             return
@@ -254,7 +325,13 @@ struct BoardCanvasView: View {
                         if currentDragMode == .moveItem {
                             commitMove()
                         } else if currentDragMode == .resizeItem {
-                            commitResize()
+                            if selection.isGroupResizing {
+                                commitGroupResize()
+                            } else {
+                                commitResize()
+                            }
+                        } else if currentDragMode == .marqueeSelect {
+                            commitMarqueeSelect()
                         }
                         currentDragMode = nil
                         dragStartOffset = nil
@@ -330,30 +407,49 @@ struct BoardCanvasView: View {
     /// Screen-space hit radius for grabbing handles
     private let handleHitRadius: CGFloat = 30
 
-    /// Check if a screen point is near any handle on the selected item.
-    /// Returns the handle position and the item's world rect if hit.
-    private func hitTestHandle(screenPoint: CGPoint) -> (HandlePosition, PlacedImage)? {
-        guard selection.selectedIDs.count == 1,
-              let selectedID = selection.selectedIDs.first,
-              let item = visibleImages.first(where: { $0.id == selectedID }) else {
-            return nil
+    private enum HandleHitResult {
+        case singleItem(handle: HandlePosition, item: PlacedImage)
+        case group(handle: HandlePosition, bbox: CGRect)
+    }
+
+    /// Pure query: hit-test screen point against handles on the current selection.
+    private func hitTestHandle(screenPoint: CGPoint) -> HandleHitResult? {
+        if selection.selectedIDs.count == 1,
+           let selectedID = selection.selectedIDs.first,
+           let item = visibleImages.first(where: { $0.id == selectedID }) {
+            let itemScreenRect = CGRect(
+                x: item.worldRect.origin.x * scale + offset.width,
+                y: item.worldRect.origin.y * scale + offset.height,
+                width: item.worldRect.width * scale,
+                height: item.worldRect.height * scale
+            )
+            if let handle = hitTestHandleOnRect(screenPoint: screenPoint, screenRect: itemScreenRect) {
+                return .singleItem(handle: handle, item: item)
+            }
+        } else if selection.selectedIDs.count > 1, let bbox = groupBoundingBox() {
+            let bboxScreenRect = CGRect(
+                x: bbox.origin.x * scale + offset.width,
+                y: bbox.origin.y * scale + offset.height,
+                width: bbox.width * scale,
+                height: bbox.height * scale
+            )
+            if let handle = hitTestHandleOnRect(screenPoint: screenPoint, screenRect: bboxScreenRect) {
+                return .group(handle: handle, bbox: bbox)
+            }
         }
+        return nil
+    }
 
-        let itemScreenRect = CGRect(
-            x: item.worldRect.origin.x * scale + offset.width,
-            y: item.worldRect.origin.y * scale + offset.height,
-            width: item.worldRect.width * scale,
-            height: item.worldRect.height * scale
-        )
-
+    /// Shared helper: hit-test a screen point against 8 handles on a screen-space rect.
+    private func hitTestHandleOnRect(screenPoint: CGPoint, screenRect: CGRect) -> HandlePosition? {
         var bestHandle: HandlePosition?
         var bestDist: CGFloat = .greatestFiniteMagnitude
 
         for handle in HandlePosition.allCases {
-            let handleScreenPt = handle.point(in: itemScreenRect.size)
+            let handleScreenPt = handle.point(in: screenRect.size)
             let handleAbsolute = CGPoint(
-                x: itemScreenRect.origin.x + handleScreenPt.x,
-                y: itemScreenRect.origin.y + handleScreenPt.y
+                x: screenRect.origin.x + handleScreenPt.x,
+                y: screenRect.origin.y + handleScreenPt.y
             )
             let dx = screenPoint.x - handleAbsolute.x
             let dy = screenPoint.y - handleAbsolute.y
@@ -363,11 +459,7 @@ struct BoardCanvasView: View {
                 bestHandle = handle
             }
         }
-
-        if let handle = bestHandle {
-            return (handle, item)
-        }
-        return nil
+        return bestHandle
     }
 
     // MARK: - Drag Helpers
@@ -387,7 +479,17 @@ struct BoardCanvasView: View {
             selection.dragOffset = CGSize(width: worldDX, height: worldDY)
             selection.isDragging = true
         case .resizeItem:
-            applyResize(translation: value.translation)
+            if selection.isGroupResizing {
+                applyGroupResize(translation: value.translation)
+            } else {
+                applyResize(translation: value.translation)
+            }
+        case .marqueeSelect:
+            let screenCurrent = CGPoint(
+                x: value.startLocation.x + value.translation.width,
+                y: value.startLocation.y + value.translation.height
+            )
+            selection.marqueeCurrentWorld = screenToWorld(screenCurrent)
         case .none:
             break
         }
@@ -395,10 +497,12 @@ struct BoardCanvasView: View {
 
     // MARK: - Resize Logic
 
-    private func applyResize(translation: CGSize) {
-        guard let handle = selection.resizeHandle,
-              let startRect = selection.resizeStartRect else { return }
-
+    /// Pure function: compute a new rect from a handle drag on a reference rect.
+    private func computeResizedRect(
+        handle: HandlePosition,
+        startRect: CGRect,
+        translation: CGSize
+    ) -> CGRect? {
         let worldDX = translation.width / scale
         let worldDY = translation.height / scale
 
@@ -415,33 +519,24 @@ struct BoardCanvasView: View {
             y: startRect.origin.y + handlePt.y + worldDY
         )
 
-        var newRect: CGRect
-
         if handle.isCorner {
-            // Aspect-ratio locked resize
             let aspect = startRect.width / max(startRect.height, 0.001)
-
             var rawW = abs(draggedWorld.x - anchorWorld.x)
             var rawH = abs(draggedWorld.y - anchorWorld.y)
 
-            // Lock aspect ratio to whichever axis moved more
             if rawW / max(aspect, 0.001) > rawH {
                 rawH = rawW / aspect
             } else {
                 rawW = rawH * aspect
             }
 
-            // Enforce minimum size
             rawW = max(rawW, minImageDimensionWorld)
             rawH = max(rawH, minImageDimensionWorld / max(aspect, 0.001))
 
-            // Build rect from anchor point, expanding toward the dragged corner
             let originX = handle.isLeftSide ? anchorWorld.x - rawW : anchorWorld.x
             let originY = handle.isTopSide ? anchorWorld.y - rawH : anchorWorld.y
-
-            newRect = CGRect(x: originX, y: originY, width: rawW, height: rawH)
+            return CGRect(x: originX, y: originY, width: rawW, height: rawH)
         } else {
-            // Single-axis edge resize
             var newOrigin = startRect.origin
             var newSize = startRect.size
 
@@ -463,12 +558,17 @@ struct BoardCanvasView: View {
                 newSize.width = newRight - anchorWorld.x
                 newOrigin.x = anchorWorld.x
             default:
-                return
+                return nil
             }
 
-            newRect = CGRect(origin: newOrigin, size: newSize)
+            return CGRect(origin: newOrigin, size: newSize)
         }
+    }
 
+    private func applyResize(translation: CGSize) {
+        guard let handle = selection.resizeHandle,
+              let startRect = selection.resizeStartRect,
+              let newRect = computeResizedRect(handle: handle, startRect: startRect, translation: translation) else { return }
         selection.resizeCurrentRect = newRect
     }
 
@@ -491,6 +591,77 @@ struct BoardCanvasView: View {
         selection.clearResize()
     }
 
+    // MARK: - Group Resize Logic
+
+    private func groupBoundingBox() -> CGRect? {
+        guard selection.selectedIDs.count > 1 else { return nil }
+        let rects = placedImages.filter { selection.selectedIDs.contains($0.id) }.map { $0.worldRect }
+        guard !rects.isEmpty else { return nil }
+        return rects.dropFirst().reduce(rects[0]) { $0.union($1) }
+    }
+
+    private func scaledRect(original: CGRect, bboxStart: CGRect, bboxCurrent: CGRect) -> CGRect {
+        let scaleX = bboxStart.width > 0.001 ? bboxCurrent.width / bboxStart.width : 1
+        let scaleY = bboxStart.height > 0.001 ? bboxCurrent.height / bboxStart.height : 1
+        let newX = bboxCurrent.origin.x + (original.origin.x - bboxStart.origin.x) * scaleX
+        let newY = bboxCurrent.origin.y + (original.origin.y - bboxStart.origin.y) * scaleY
+        let newW = original.width * scaleX
+        let newH = original.height * scaleY
+        return CGRect(x: newX, y: newY, width: newW, height: newH)
+    }
+
+    private func applyGroupResize(translation: CGSize) {
+        guard let handle = selection.resizeHandle,
+              let bboxStart = selection.groupResizeBBoxStart,
+              let newBBox = computeResizedRect(handle: handle, startRect: bboxStart, translation: translation) else { return }
+        selection.groupResizeBBoxCurrent = newBBox
+    }
+
+    private func commitGroupResize() {
+        guard let startRects = selection.groupResizeStartRects,
+              let bboxStart = selection.groupResizeBBoxStart,
+              let bboxCurrent = selection.groupResizeBBoxCurrent,
+              bboxStart != bboxCurrent else {
+            selection.clearGroupResize()
+            return
+        }
+
+        var toRects: [UUID: CGRect] = [:]
+        for (id, originalRect) in startRects {
+            toRects[id] = scaledRect(original: originalRect, bboxStart: bboxStart, bboxCurrent: bboxCurrent)
+        }
+
+        commandHistory.push(.groupResize(fromRects: startRects, toRects: toRects))
+
+        for (id, rect) in toRects {
+            applyResizeRect(elementID: id, rect: rect)
+        }
+        selection.clearGroupResize()
+    }
+
+    // MARK: - Marquee Select
+
+    private func commitMarqueeSelect() {
+        guard let rect = selection.marqueeWorldRect else {
+            selection.clearMarquee()
+            return
+        }
+
+        let cmRect = CMWorldRect(
+            origin: SIMD2<Double>(Double(rect.origin.x), Double(rect.origin.y)),
+            size: SIMD2<Double>(Double(rect.width), Double(rect.height))
+        )
+
+        let store = canvasStore
+        Task { @MainActor in
+            let headers = await store.headers(in: cmRect, limit: nil)
+            let ids = Set(headers.map { $0.id })
+            selection.selectedIDs = ids
+            selection.clearMarquee()
+            await refreshVisibleElements()
+        }
+    }
+
     private func commitMove() {
         let dx = selection.dragOffset.width
         let dy = selection.dragOffset.height
@@ -510,6 +681,10 @@ struct BoardCanvasView: View {
             applyMoveDelta(elementIDs: ids, dx: -delta.width, dy: -delta.height)
         case .resize(let id, let fromRect, _):
             applyResizeRect(elementID: id, rect: fromRect)
+        case .groupResize(let fromRects, _):
+            for (id, rect) in fromRects {
+                applyResizeRect(elementID: id, rect: rect)
+            }
         case .insert(let snapshots):
             removeElements(snapshots: snapshots)
         case .delete(let snapshots):
@@ -524,6 +699,10 @@ struct BoardCanvasView: View {
             applyMoveDelta(elementIDs: ids, dx: delta.width, dy: delta.height)
         case .resize(let id, _, let toRect):
             applyResizeRect(elementID: id, rect: toRect)
+        case .groupResize(_, let toRects):
+            for (id, rect) in toRects {
+                applyResizeRect(elementID: id, rect: rect)
+            }
         case .insert(let snapshots):
             addElements(snapshots: snapshots)
         case .delete(let snapshots):
@@ -532,6 +711,19 @@ struct BoardCanvasView: View {
     }
 
     // MARK: - Command Execution Helpers
+
+    /// Enqueue a serialized store mutation. Cancels any in-flight mutation first,
+    /// then awaits its completion before running the new one.
+    private func enqueueStoreMutation(_ work: @escaping @Sendable (LocalBoardStore) async -> Void) {
+        let previous = storeMutationTask
+        let store = canvasStore
+        storeMutationTask = Task { @MainActor in
+            previous?.cancel()
+            _ = await previous?.result  // wait for cancellation to settle
+            await work(store)
+            await refreshVisibleElements()
+        }
+    }
 
     private func applyMoveDelta(elementIDs: Set<UUID>, dx: CGFloat, dy: CGFloat) {
         for i in placedImages.indices {
@@ -547,8 +739,8 @@ struct BoardCanvasView: View {
             }
         }
 
-        Task {
-            let fetched = await canvasStore.elements(for: Array(elementIDs))
+        enqueueStoreMutation { store in
+            let fetched = await store.elements(for: Array(elementIDs))
             var updated: [CMCanvasElement] = []
             for (_, var element) in fetched {
                 element.header.bounds.origin.x += Double(dx)
@@ -556,9 +748,8 @@ struct BoardCanvasView: View {
                 updated.append(element)
             }
             if !updated.isEmpty {
-                await canvasStore.upsert(elements: updated)
+                await store.upsert(elements: updated)
             }
-            await refreshVisibleElements()
         }
     }
 
@@ -570,8 +761,7 @@ struct BoardCanvasView: View {
             visibleImages[idx].worldRect = rect
         }
 
-        let store = canvasStore
-        Task {
+        enqueueStoreMutation { store in
             let fetched = await store.elements(for: [elementID])
             if var element = fetched[elementID] {
                 element.header.bounds = CMWorldRect(
@@ -586,7 +776,6 @@ struct BoardCanvasView: View {
                 }
                 await store.upsert(elements: [element])
             }
-            await refreshVisibleElements()
         }
     }
 
@@ -597,9 +786,8 @@ struct BoardCanvasView: View {
         }
 
         let elements = snapshots.map { $0.element }
-        Task {
-            await canvasStore.upsert(elements: elements)
-            await refreshVisibleElements()
+        enqueueStoreMutation { store in
+            await store.upsert(elements: elements)
         }
     }
 
@@ -609,9 +797,8 @@ struct BoardCanvasView: View {
         visibleImages.removeAll { idsToRemove.contains($0.id) }
         selection.selectedIDs.subtract(idsToRemove)
 
-        Task {
-            await canvasStore.delete(elementIDs: Array(idsToRemove))
-            await refreshVisibleElements()
+        enqueueStoreMutation { store in
+            await store.delete(elementIDs: Array(idsToRemove))
         }
     }
 

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -294,27 +294,30 @@ struct BoardCanvasView: View {
                                 return
                             }
 
-                            // Normal tool behavior routing
+                            // Normal tool behavior routing (synchronous — no async race)
                             let worldStart = screenToWorld(value.startLocation)
                             dragStartWorldPos = worldStart
                             let behavior = toolBehavior(for: activeTool)
-                            let store = canvasStore
-                            let sel = selection
-                            // Set sentinel to prevent re-entry while awaiting
-                            currentDragMode = DragMode.none
-                            Task { @MainActor in
-                                let mode = await behavior.dragBegan(
-                                    worldStart: worldStart,
-                                    store: store,
-                                    selection: sel
-                                )
-                                currentDragMode = mode
-                                if mode == .marqueeSelect {
-                                    selection.marqueeStartWorld = worldStart
-                                    selection.marqueeCurrentWorld = worldStart
-                                }
-                                applyDrag(value: value, mode: mode)
+                            let items = placedImages.map {
+                                HitTestItem(id: $0.id, worldRect: $0.worldRect, zIndex: $0.zIndex)
                             }
+                            let mode = behavior.dragBegan(
+                                worldStart: worldStart,
+                                items: items,
+                                selection: selection
+                            )
+                            currentDragMode = mode
+                            if mode == .marqueeSelect {
+                                selection.marqueeStartWorld = worldStart
+                                selection.marqueeCurrentWorld = worldStart
+                            }
+                            // Fire-and-forget: reorder in store for z-order persistence
+                            if mode == .moveItem {
+                                let store = canvasStore
+                                let ids = Array(selection.selectedIDs)
+                                Task { await store.moveToTop(elementIDs: ids) }
+                            }
+                            applyDrag(value: value, mode: mode)
                             return
                         }
                         if let mode = currentDragMode {
@@ -632,10 +635,7 @@ struct BoardCanvasView: View {
         }
 
         commandHistory.push(.groupResize(fromRects: startRects, toRects: toRects))
-
-        for (id, rect) in toRects {
-            applyResizeRect(elementID: id, rect: rect)
-        }
+        applyResizeRects(toRects)
         selection.clearGroupResize()
     }
 
@@ -682,9 +682,7 @@ struct BoardCanvasView: View {
         case .resize(let id, let fromRect, _):
             applyResizeRect(elementID: id, rect: fromRect)
         case .groupResize(let fromRects, _):
-            for (id, rect) in fromRects {
-                applyResizeRect(elementID: id, rect: rect)
-            }
+            applyResizeRects(fromRects)
         case .insert(let snapshots):
             removeElements(snapshots: snapshots)
         case .delete(let snapshots):
@@ -700,9 +698,7 @@ struct BoardCanvasView: View {
         case .resize(let id, _, let toRect):
             applyResizeRect(elementID: id, rect: toRect)
         case .groupResize(_, let toRects):
-            for (id, rect) in toRects {
-                applyResizeRect(elementID: id, rect: rect)
-            }
+            applyResizeRects(toRects)
         case .insert(let snapshots):
             addElements(snapshots: snapshots)
         case .delete(let snapshots):
@@ -776,6 +772,42 @@ struct BoardCanvasView: View {
                 }
                 await store.upsert(elements: [element])
             }
+        }
+    }
+
+    /// Batch-apply multiple resize rects in a single store mutation (used by group resize + undo/redo).
+    private func applyResizeRects(_ rects: [UUID: CGRect]) {
+        // Update in-memory arrays synchronously
+        for (id, rect) in rects {
+            if let idx = placedImages.firstIndex(where: { $0.id == id }) {
+                placedImages[idx].worldRect = rect
+            }
+            if let idx = visibleImages.firstIndex(where: { $0.id == id }) {
+                visibleImages[idx].worldRect = rect
+            }
+        }
+
+        // Single batched store mutation
+        let ids = Array(rects.keys)
+        enqueueStoreMutation { store in
+            let fetched = await store.elements(for: ids)
+            var updated: [CMCanvasElement] = []
+            for (id, rect) in rects {
+                if var element = fetched[id] {
+                    element.header.bounds = CMWorldRect(
+                        origin: SIMD2<Double>(Double(rect.origin.x), Double(rect.origin.y)),
+                        size: SIMD2<Double>(Double(rect.width), Double(rect.height))
+                    )
+                    if case .image(let url, _) = element.payload {
+                        element.payload = .image(
+                            url: url,
+                            size: SIMD2<Double>(Double(rect.width), Double(rect.height))
+                        )
+                    }
+                    updated.append(element)
+                }
+            }
+            await store.upsert(elements: updated)
         }
     }
 

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
@@ -13,6 +13,7 @@ struct PlacedElementSnapshot {
 enum CanvasCommand {
     case move(elementIDs: Set<UUID>, delta: CGSize)
     case resize(elementID: UUID, fromRect: CGRect, toRect: CGRect)
+    case groupResize(fromRects: [UUID: CGRect], toRects: [UUID: CGRect])
     case insert(snapshots: [PlacedElementSnapshot])
     case delete(snapshots: [PlacedElementSnapshot])
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSelectionState.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSelectionState.swift
@@ -43,4 +43,47 @@ final class CanvasSelectionState {
         resizeCurrentRect = nil
         resizeElementID = nil
     }
+
+    // MARK: - Marquee state
+
+    /// World-space anchor point of the marquee drag
+    var marqueeStartWorld: CGPoint?
+    /// World-space current corner of the marquee drag
+    var marqueeCurrentWorld: CGPoint?
+
+    var isMarqueeing: Bool { marqueeStartWorld != nil }
+
+    /// Normalized world-space rect of the active marquee
+    var marqueeWorldRect: CGRect? {
+        guard let start = marqueeStartWorld, let current = marqueeCurrentWorld else { return nil }
+        return CGRect(
+            x: min(start.x, current.x),
+            y: min(start.y, current.y),
+            width: abs(current.x - start.x),
+            height: abs(current.y - start.y)
+        )
+    }
+
+    func clearMarquee() {
+        marqueeStartWorld = nil
+        marqueeCurrentWorld = nil
+    }
+
+    // MARK: - Group resize state
+
+    /// Original world rects of all selected items at resize start
+    var groupResizeStartRects: [UUID: CGRect]?
+    /// Group bounding box at resize start
+    var groupResizeBBoxStart: CGRect?
+    /// Live group bounding box during resize
+    var groupResizeBBoxCurrent: CGRect?
+
+    var isGroupResizing: Bool { groupResizeStartRects != nil }
+
+    func clearGroupResize() {
+        groupResizeStartRects = nil
+        groupResizeBBoxStart = nil
+        groupResizeBBoxCurrent = nil
+        resizeHandle = nil
+    }
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
@@ -4,6 +4,7 @@ enum DragMode {
     case pan
     case moveItem
     case resizeItem
+    case marqueeSelect
     case none
 }
 
@@ -58,11 +59,25 @@ struct PointerToolBehavior: CanvasToolBehavior {
 
 struct GroupToolBehavior: CanvasToolBehavior {
     func dragBegan(worldStart: CGPoint, store: LocalBoardStore, selection: CanvasSelectionState) async -> DragMode {
-        return .pan
+        let point = SIMD2<Double>(Double(worldStart.x), Double(worldStart.y))
+        if let header = await store.topmostHeader(at: point) {
+            if !selection.selectedIDs.contains(header.id) {
+                await MainActor.run { selection.select(header.id, extending: true) }
+            }
+            await store.moveToTop(elementIDs: Array(selection.selectedIDs))
+            return .moveItem
+        } else {
+            return .marqueeSelect
+        }
     }
 
     func tapped(worldPoint: CGPoint, store: LocalBoardStore, selection: CanvasSelectionState) async {
-        // Future: toggle group membership
+        let point = SIMD2<Double>(Double(worldPoint.x), Double(worldPoint.y))
+        if let header = await store.topmostHeader(at: point) {
+            await MainActor.run { selection.select(header.id, extending: true) }
+        } else {
+            await MainActor.run { selection.clearSelection() }
+        }
     }
 }
 

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
@@ -8,13 +8,20 @@ enum DragMode {
     case none
 }
 
+/// Lightweight item descriptor for synchronous hit-testing against in-memory placed images.
+struct HitTestItem {
+    let id: UUID
+    let worldRect: CGRect
+    let zIndex: Int
+}
+
 protocol CanvasToolBehavior {
-    /// Called on first drag event to decide what this drag does.
+    /// Synchronous mode decision using in-memory placed images (no store round-trip).
     func dragBegan(
         worldStart: CGPoint,
-        store: LocalBoardStore,
+        items: [HitTestItem],
         selection: CanvasSelectionState
-    ) async -> DragMode
+    ) -> DragMode
 
     /// Called on tap (drag that ends without meaningful translation).
     func tapped(
@@ -27,19 +34,22 @@ protocol CanvasToolBehavior {
 struct PointerToolBehavior: CanvasToolBehavior {
     func dragBegan(
         worldStart: CGPoint,
-        store: LocalBoardStore,
+        items: [HitTestItem],
         selection: CanvasSelectionState
-    ) async -> DragMode {
-        let point = SIMD2<Double>(Double(worldStart.x), Double(worldStart.y))
-        if let header = await store.topmostHeader(at: point) {
-            if !selection.selectedIDs.contains(header.id) {
-                await MainActor.run { selection.select(header.id) }
+    ) -> DragMode {
+        if let hit = Self.topmostItem(at: worldStart, in: items) {
+            if !selection.selectedIDs.contains(hit.id) {
+                selection.select(hit.id)
             }
-            await store.moveToTop(elementIDs: Array(selection.selectedIDs))
             return .moveItem
         } else {
             return .pan
         }
+    }
+
+    static func topmostItem(at point: CGPoint, in items: [HitTestItem]) -> HitTestItem? {
+        items.filter { $0.worldRect.contains(point) }
+             .max(by: { $0.zIndex < $1.zIndex })
     }
 
     func tapped(
@@ -58,13 +68,11 @@ struct PointerToolBehavior: CanvasToolBehavior {
 }
 
 struct GroupToolBehavior: CanvasToolBehavior {
-    func dragBegan(worldStart: CGPoint, store: LocalBoardStore, selection: CanvasSelectionState) async -> DragMode {
-        let point = SIMD2<Double>(Double(worldStart.x), Double(worldStart.y))
-        if let header = await store.topmostHeader(at: point) {
-            if !selection.selectedIDs.contains(header.id) {
-                await MainActor.run { selection.select(header.id, extending: true) }
+    func dragBegan(worldStart: CGPoint, items: [HitTestItem], selection: CanvasSelectionState) -> DragMode {
+        if let hit = PointerToolBehavior.topmostItem(at: worldStart, in: items) {
+            if !selection.selectedIDs.contains(hit.id) {
+                selection.select(hit.id, extending: true)
             }
-            await store.moveToTop(elementIDs: Array(selection.selectedIDs))
             return .moveItem
         } else {
             return .marqueeSelect

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/MarqueeOverlayView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/MarqueeOverlayView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct MarqueeOverlayView: View {
+    let screenRect: CGRect
+
+    var body: some View {
+        Rectangle()
+            .fill(DesignSystem.Colors.tertiary.opacity(0.08))
+            .overlay(
+                Rectangle()
+                    .strokeBorder(
+                        style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
+                    )
+                    .foregroundStyle(DesignSystem.Colors.tertiary)
+            )
+            .frame(width: screenRect.width, height: screenRect.height)
+            .position(x: screenRect.midX, y: screenRect.midY)
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/SelectionOverlay.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/SelectionOverlay.swift
@@ -1,30 +1,52 @@
 import SwiftUI
 
-struct SelectionOverlay: View {
-    private let handleSize: CGFloat = 10
-    private let borderWidth: CGFloat = 2
+/// Shared resize handle used by both single-item and group selection overlays.
+private struct ResizeHandleView: View {
+    private let size: CGFloat = 10
 
     var body: some View {
-        GeometryReader { geo in
-            // Border
-            Rectangle()
-                .strokeBorder(DesignSystem.Colors.tertiary, lineWidth: borderWidth)
-
-            // Corner handles
-            ForEach(HandlePosition.allCases, id: \.self) { position in
-                handleView
-                    .position(position.point(in: geo.size))
-            }
-        }
-    }
-
-    private var handleView: some View {
         RoundedRectangle(cornerRadius: 2)
             .fill(Color.white)
-            .frame(width: handleSize, height: handleSize)
+            .frame(width: size, height: size)
             .overlay(
                 RoundedRectangle(cornerRadius: 2)
                     .strokeBorder(DesignSystem.Colors.tertiary, lineWidth: 1.5)
             )
+    }
+}
+
+struct SelectionOverlay: View {
+    private let borderWidth: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .strokeBorder(DesignSystem.Colors.tertiary, lineWidth: borderWidth)
+
+            ForEach(HandlePosition.allCases, id: \.self) { position in
+                ResizeHandleView()
+                    .position(position.point(in: geo.size))
+            }
+        }
+    }
+}
+
+/// Selection overlay for a multi-select group bounding box (dashed border).
+struct GroupSelectionOverlay: View {
+    private let borderWidth: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .strokeBorder(
+                    style: StrokeStyle(lineWidth: borderWidth, dash: [8, 4])
+                )
+                .foregroundStyle(DesignSystem.Colors.tertiary)
+
+            ForEach(HandlePosition.allCases, id: \.self) { position in
+                ResizeHandleView()
+                    .position(position.point(in: geo.size))
+            }
+        }
     }
 }

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -284,7 +284,7 @@ CanvasTool (enum)              -- toolbar identity, UI selection
     v
 CanvasToolBehavior (protocol)  -- gesture interpretation per tool
     ├── PointerToolBehavior    -- tap=select, drag-on-item=move, drag-on-empty=pan
-    └── GroupToolBehavior      -- stub (falls back to pan for now)
+    └── GroupToolBehavior      -- tap=toggle selection, drag-on-item=group move, drag-on-empty=marquee select
 ```
 
 **Protocol:**
@@ -296,14 +296,15 @@ protocol CanvasToolBehavior {
 }
 ```
 
-**DragMode enum:** `.pan`, `.moveItem`, `.none`
+**DragMode enum:** `.pan`, `.moveItem`, `.resizeItem`, `.marqueeSelect`, `.none`
 
 **Gesture Routing:**
 
 A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the active tool's behavior:
-1. On first `.onChanged` event: hit-test via tool behavior → cache `DragMode` for gesture duration
-2. Subsequent `.onChanged`: `applyDrag()` routes to pan or move based on cached mode
-3. `.onEnded`: if translation < 4pt, treat as tap → call `behavior.tapped()`; if `.moveItem`, call `commitMove()`
+1. On first `.onChanged` event: handle hit-test first (resize), then tool behavior → cache `DragMode` for gesture duration
+2. A `DragMode.none` sentinel is set synchronously before the async `dragBegan` call to prevent re-entry from subsequent events arriving before the Task completes
+3. Subsequent `.onChanged`: `applyDrag()` routes to pan, move, resize, or marquee based on cached mode
+4. `.onEnded`: commits the appropriate action (move, resize, group resize, or marquee select)
 
 **Pointer Tool Behavior:**
 - Drag on item → select it, bring to top, enter `.moveItem` mode
@@ -311,7 +312,12 @@ A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the
 - Tap on item → select it
 - Tap on empty → clear selection
 
-**Group Tool:** Stub — returns `.pan` for all drags, no-op for taps. Ready for future marquee select.
+**Group Tool Behavior:**
+- Drag on selected item → `.moveItem` mode (group move)
+- Drag on unselected item → add to selection via `extending: true`, `.moveItem` mode
+- Drag on empty canvas → `.marqueeSelect` mode (draws selection rectangle)
+- Tap on item → toggle selection membership (`extending: true`)
+- Tap on empty → clear selection
 
 **Factory:** `toolBehavior(for: CanvasTool) -> CanvasToolBehavior` maps enum to concrete behavior.
 
@@ -326,7 +332,7 @@ A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the
 
 **Status: Implemented**
 
-**Files:** `CanvasSelectionState.swift`, `HandlePosition.swift`, `SelectionOverlay.swift`, `BoardCanvasView.swift`
+**Files:** `CanvasSelectionState.swift`, `HandlePosition.swift`, `SelectionOverlay.swift`, `MarqueeOverlayView.swift`, `BoardCanvasView.swift`
 
 **Selection State:**
 
@@ -334,16 +340,26 @@ A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the
 - `selectedIDs: Set<UUID>` — currently selected element IDs
 - `dragOffset: CGSize` — world-space offset during active drag-move
 - `isDragging: Bool` — whether a move drag is in progress
-- `select(_:extending:)` — select an item (extending parameter for future multi-select)
+- `select(_:extending:)` — select an item (`extending: true` toggles membership for multi-select)
 - `clearSelection()` — deselect all
+
+**Marquee State** (in `CanvasSelectionState`):
+- `marqueeStartWorld: CGPoint?` — world-space anchor of the marquee drag
+- `marqueeCurrentWorld: CGPoint?` — world-space current corner
+- `marqueeWorldRect: CGRect?` — computed normalized rect
+- `isMarqueeing: Bool` — computed from `marqueeStartWorld != nil`
+- `clearMarquee()` — resets marquee state
 
 **Visual Indicators:**
 
-**Files:** `SelectionOverlay.swift` (view), `HandlePosition.swift` (data model)
+**Files:** `SelectionOverlay.swift` (views), `HandlePosition.swift` (data model)
 
-Selected items display a `SelectionOverlay` via `.overlay` (applied before `.position()` so it renders in the item's coordinate space):
-- Blue stroke border (`DesignSystem.Colors.tertiary`, 2pt)
-- White handles (10×10pt rounded rectangles with blue border) at 8 positions: 4 corners + 4 edge midpoints
+- `ResizeHandleView` — shared 10×10pt rounded rectangle handle with white fill and tertiary border, used by both overlay types
+- `SelectionOverlay` — solid blue border + 8 handles, shown on single-selected items
+- `GroupSelectionOverlay` — dashed blue border + 8 handles, shown on the group bounding box when multiple items are selected
+- When multi-selected, individual items show a light semi-transparent border instead of full handles
+- `MarqueeOverlayView` — dashed rectangle with semi-transparent fill, shown during marquee drag
+
 - `HandlePosition` enum (in `HandlePosition.swift`) defines `.topLeft`, `.topCenter`, `.topRight`, `.leftCenter`, `.rightCenter`, `.bottomLeft`, `.bottomCenter`, `.bottomRight`
 - Extracted to its own file to avoid coupling `CanvasSelectionState` to the view layer
 - Each handle has helper properties: `anchorPosition` (opposite handle), `isCorner`, `isLeftSide`, `isTopSide`
@@ -356,29 +372,51 @@ Selected items display a `SelectionOverlay` via `.overlay` (applied before `.pos
 
 **Resize Interaction:**
 
-**Status: Implemented**
+**Status: Implemented (single + group)**
 
-1. On drag start, `hitTestHandle(screenPoint:)` checks screen-space distance to all 8 handles on the selected item (hit radius: 30pt)
-2. If a handle is hit → `.resizeItem` drag mode, bypassing tool behavior routing
-3. During drag, `applyResize(translation:)` computes the new world rect:
-   - **Corner handles:** aspect-ratio-locked resize, opposite corner pinned
-   - **Edge handles:** single-axis stretch (width or height only), opposite edge pinned
-   - Minimum dimension enforced (`minImageDimensionWorld = 64`)
-4. Live rect stored in `selection.resizeCurrentRect`, used by render loop for immediate visual feedback
-5. On drag end, `commitResize()` skips no-op resizes (where `newRect == startRect`), then pushes a `.resize` command to history and applies via `applyResizeRect()`
-6. Single-select only for now; resize is skipped if multiple items are selected
+`hitTestHandle(screenPoint:)` is a pure query returning a `HandleHitResult` enum (`.singleItem` or `.group`). The call site in the gesture handler sets up the appropriate resize state based on the result.
 
-**Resize State** (in `CanvasSelectionState`):
-- `resizeHandle: HandlePosition?` — which handle is being dragged
+**Single-item resize** (1 item selected):
+1. `hitTestHandle` checks screen-space distance to 8 handles on the item (hit radius: 30pt)
+2. If hit → `.resizeItem` drag mode, populates single resize state
+3. During drag, `applyResize(translation:)` delegates to `computeResizedRect()` (shared pure function)
+4. Live rect stored in `selection.resizeCurrentRect`
+5. `commitResize()` skips no-op resizes, pushes `.resize` command
+
+**Group resize** (2+ items selected):
+1. `hitTestHandle` checks handles on the group bounding box
+2. If hit → `.resizeItem` drag mode, snapshots all selected items' rects into `groupResizeStartRects`
+3. During drag, `applyGroupResize(translation:)` delegates to `computeResizedRect()` on the group bbox
+4. Each item's live rect is computed via `scaledRect(original:bboxStart:bboxCurrent:)`:
+   - `scaleX = bboxCurrent.width / bboxStart.width`
+   - `scaleY = bboxCurrent.height / bboxStart.height`
+   - Position and size scaled relative to bbox origin
+5. `commitGroupResize()` pushes `.groupResize(fromRects:toRects:)` command, applies each rect via `applyResizeRect`
+
+**Shared resize math:** `computeResizedRect(handle:startRect:translation:) -> CGRect?`
+- Corner handles: aspect-ratio-locked resize, opposite corner pinned
+- Edge handles: single-axis stretch, opposite edge pinned
+- Minimum dimension enforced (`minImageDimensionWorld = 64`)
+- Used by both single and group resize paths
+
+**Single Resize State** (in `CanvasSelectionState`):
+- `resizeHandle: HandlePosition?` — which handle is being dragged (shared with group resize)
 - `resizeStartRect: CGRect?` — element's world rect at drag start
 - `resizeCurrentRect: CGRect?` — live rect during drag
 - `resizeElementID: UUID?` — element being resized
 - `isResizing: Bool` — computed from `resizeHandle != nil`
-- `clearResize()` — resets all resize state
+- `clearResize()` — resets all single resize state
+
+**Group Resize State** (in `CanvasSelectionState`):
+- `groupResizeStartRects: [UUID: CGRect]?` — original rects of all selected items
+- `groupResizeBBoxStart: CGRect?` — group bounding box at resize start
+- `groupResizeBBoxCurrent: CGRect?` — live bounding box during resize
+- `isGroupResizing: Bool` — computed from `groupResizeStartRects != nil`
+- `clearGroupResize()` — resets all group resize state
 
 **Performance:**
 
-Store updates are batched — one `elements(for:)` fetch + one `upsert(elements:)` call regardless of selection count (2 actor round-trips, not 2N). This scales for future multi-select.
+Store updates are serialized via `enqueueStoreMutation()` — each mutation cancels any in-flight task and awaits its completion before running. This prevents stale writes from rapid undo/redo or overlapping operations. Each mutation uses batched `elements(for:)` + `upsert(elements:)` calls (2 actor round-trips, not 2N).
 
 ---
 
@@ -405,6 +443,7 @@ ContentView                  — triggers undo/redo from toolbar
 |---------|-------------|------|------|
 | `.move` | `elementIDs: Set<UUID>`, `delta: CGSize` | Move by -delta | Move by +delta |
 | `.resize` | `elementID: UUID`, `fromRect`, `toRect` | Restore fromRect | Restore toRect |
+| `.groupResize` | `fromRects: [UUID: CGRect]`, `toRects: [UUID: CGRect]` | Restore all fromRects | Apply all toRects |
 | `.insert` | `snapshots: [PlacedElementSnapshot]` | Remove elements | Re-add elements |
 | `.delete` | `snapshots: [PlacedElementSnapshot]` | Re-add elements | Remove elements |
 
@@ -635,18 +674,20 @@ FilePickerView(onFilesSelected: ([URL]) -> Void)
 2. **Tool Behavior:**
    - ~~Connect `activeTool` state to actual canvas interactions~~ ✅ Done
    - ~~Implement selection via pointer tool~~ ✅ Done
-   - Implement selection rectangles / marquee select for group tool
-   - Implement grouping behavior for group tool
+   - ~~Implement selection rectangles / marquee select for group tool~~ ✅ Done
+   - ~~Implement group move/resize behavior for group tool~~ ✅ Done
 
 3. **Item Interaction:**
    - ~~Select items on tap~~ ✅ Done
    - ~~Move items by dragging~~ ✅ Done
    - ~~Resize handle visuals~~ ✅ Done
    - ~~Functional resize via corner and edge handle drag~~ ✅ Done
-   - ~~Undo/redo for move, resize, and insert~~ ✅ Done
+   - ~~Undo/redo for move, resize, insert, and group resize~~ ✅ Done
+   - ~~Multi-selection via marquee and toggle-tap~~ ✅ Done
+   - ~~Group move (all selected items move together)~~ ✅ Done
+   - ~~Group resize (proportional scaling relative to group bounding box)~~ ✅ Done
    - Delete selected items (command exists, needs UI trigger)
    - Rotation gestures
-   - Multi-selection (CanvasSelectionState already supports it via `extending` parameter)
 
 4. **File Import Refactor:**
    - Extract duplicate file loading code into `FileImportHelpers.swift`
@@ -687,7 +728,9 @@ FilePickerView(onFilesSelected: ([URL]) -> Void)
 
 3. **Persistence:**
    - Dev A manages `placedImages` in `@State` and syncs to `LocalBoardStore` on insert, move, resize, and delete
+   - All store mutations are serialized via `enqueueStoreMutation()` — cancels previous task, awaits completion, then runs
    - Move/resize operations use `elements(for:)` + `upsert(elements:)` for batched updates
+   - Marquee select uses `headers(in: CMWorldRect)` for spatial rectangle query
    - Insert undo uses `delete(elementIDs:)` to remove elements from the store
    - Hit testing uses `topmostHeader(at:)` from `LocalBoardStore`
    - `moveToTop(elementIDs:)` used to bring selected items to front on interaction

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -290,11 +290,15 @@ CanvasToolBehavior (protocol)  -- gesture interpretation per tool
 **Protocol:**
 
 ```swift
+struct HitTestItem { let id: UUID; let worldRect: CGRect; let zIndex: Int }
+
 protocol CanvasToolBehavior {
-    func dragBegan(worldStart: CGPoint, store: LocalBoardStore, selection: CanvasSelectionState) async -> DragMode
+    func dragBegan(worldStart: CGPoint, items: [HitTestItem], selection: CanvasSelectionState) -> DragMode
     func tapped(worldPoint: CGPoint, store: LocalBoardStore, selection: CanvasSelectionState) async
 }
 ```
+
+`dragBegan` is **synchronous** — it hit-tests against in-memory `placedImages` (mapped to `HitTestItem`) instead of querying the async store. This eliminates a race where quick drags could end before the async mode decision completed. The `moveToTop` z-order persistence is fired as a non-blocking side effect after mode is set.
 
 **DragMode enum:** `.pan`, `.moveItem`, `.resizeItem`, `.marqueeSelect`, `.none`
 
@@ -302,7 +306,7 @@ protocol CanvasToolBehavior {
 
 A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the active tool's behavior:
 1. On first `.onChanged` event: handle hit-test first (resize), then tool behavior → cache `DragMode` for gesture duration
-2. A `DragMode.none` sentinel is set synchronously before the async `dragBegan` call to prevent re-entry from subsequent events arriving before the Task completes
+2. Mode decision is synchronous — no async gap between first event and mode being set
 3. Subsequent `.onChanged`: `applyDrag()` routes to pan, move, resize, or marquee based on cached mode
 4. `.onEnded`: commits the appropriate action (move, resize, group resize, or marquee select)
 
@@ -391,7 +395,7 @@ A single `DragGesture(minimumDistance: 8)` on the canvas ZStack delegates to the
    - `scaleX = bboxCurrent.width / bboxStart.width`
    - `scaleY = bboxCurrent.height / bboxStart.height`
    - Position and size scaled relative to bbox origin
-5. `commitGroupResize()` pushes `.groupResize(fromRects:toRects:)` command, applies each rect via `applyResizeRect`
+5. `commitGroupResize()` pushes `.groupResize(fromRects:toRects:)` command, applies all rects in a single batch via `applyResizeRects(_:)`
 
 **Shared resize math:** `computeResizedRect(handle:startRect:translation:) -> CGRect?`
 - Corner handles: aspect-ratio-locked resize, opposite corner pinned
@@ -460,7 +464,7 @@ ContentView                  — triggers undo/redo from toolbar
 
 - Toolbar undo/redo buttons fire UUID trigger bindings (`undoTrigger`, `redoTrigger`)
 - `BoardCanvasView` observes triggers via `.onChange` and calls `performUndo()` / `performRedo()`
-- Each method pops a command and dispatches to shared helpers: `applyMoveDelta()`, `applyResizeRect()`, `addElements()`, `removeElements()`
+- Each method pops a command and dispatches to shared helpers: `applyMoveDelta()`, `applyResizeRect()`, `applyResizeRects(_:)` (batched group resize), `addElements()`, `removeElements()`
 
 **Adding New Undoable Operations:**
 


### PR DESCRIPTION
Closes #33

## Summary
- **Marquee select** — group tool drag on empty canvas draws a dashed selection rectangle; items within are selected on release via tile-indexed spatial query
- **Group move** — all selected items move together as a unit when dragging any selected item
- **Group resize** — drag handles on the group bounding box to proportionally scale all items (corners lock aspect ratio, edges single-axis)
- **Architecture review fixes** — drag race sentinel, serialized store mutations via `enqueueStoreMutation`, shared `computeResizedRect` (dedup ~50 lines), shared `ResizeHandleView`, pure `hitTestHandle` returning `HandleHitResult`
- **File importer bug fix** — import picker now reopens correctly after dismissing without selection
- **Architecture docs updated** with all new systems

## Test plan
- [x] Switch to group tool, drag on empty canvas → dashed marquee rectangle appears
- [x] Release marquee → items within rect are selected, group bbox with handles appears
- [x] Drag a selected item → all selected items move together
- [x] Drag corner handle on group bbox → all items resize proportionally
- [x] Drag edge handle → single-axis stretch for all items
- [x] Undo/redo group resize → all items revert/restore correctly
- [x] Tap item with group tool → toggles selection membership
- [x] Switch to pointer tool with multi-selection → group bbox still visible
- [x] Tap Import, dismiss without selecting, tap Import again → picker reopens
- [x] Import a .refboard board → canvas loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)