### PR TITLE
Frontend: two-finger pan, undo-fix, SwiftUI modernization

### DIFF
--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -59,12 +59,14 @@ struct ContentView: View {
                 }
             )
             
-            // Dynamic layout based on toolbar side
-            if toolbarSide == .left {
-                leftSideLayout
-            } else {
-                rightSideLayout
-            }
+            CanvasOverlayLayout(
+                side: toolbarSide,
+                activeTool: $activeTool,
+                onUndo: { undoTrigger = UUID() },
+                onRedo: { redoTrigger = UUID() },
+                onAddItem: openImageImporter,
+                onSettings: { showingSettings = true }
+            )
         }
         .overlay(alignment: .topTrailing) {
             HStack(spacing: 8) {
@@ -147,76 +149,10 @@ struct ContentView: View {
         }
     }
     
-    // MARK: - Layout Variants
-    
-    private var leftSideLayout: some View {
-        Group {
-            // Main toolbar (centered vertically on left side)
-            HStack {
-                CanvasToolbar(
-                    activeTool: $activeTool,
-                    onUndo: { undoTrigger = UUID() },
-                    onRedo: { redoTrigger = UUID() },
-                    onAddItem: {
-                        print("[UI] Add Item tapped")
-                        importerMode = .images
-                        lastImporterMode = .images
-                    }
-                )
-                .padding(.leading, 16)
-                
-                Spacer()
-            }
-            
-            // Settings button (bottom-left)
-            VStack {
-                Spacer()
-                HStack {
-                    CanvasSettingsButton {
-                        showingSettings = true
-                    }
-                    .padding(.leading, 16)
-                    .padding(.bottom, 16)
-                    
-                    Spacer()
-                }
-            }
-        }
-    }
-    
-    private var rightSideLayout: some View {
-        Group {
-            // Main toolbar (centered vertically on right side)
-            HStack {
-                Spacer()
-                
-                CanvasToolbar(
-                    activeTool: $activeTool,
-                    onUndo: { undoTrigger = UUID() },
-                    onRedo: { redoTrigger = UUID() },
-                    onAddItem: {
-                        print("[UI] Add Item tapped")
-                        importerMode = .images
-                        lastImporterMode = .images
-                    }
-                )
-                .padding(.trailing, 16)
-            }
-            
-            // Settings button (bottom-right)
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    
-                    CanvasSettingsButton {
-                        showingSettings = true
-                    }
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 16)
-                }
-            }
-        }
+    private func openImageImporter() {
+        print("[UI] Add Item tapped")
+        importerMode = .images
+        lastImporterMode = .images
     }
 }
 

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct ContentView: View {
-    @EnvironmentObject private var openHandler: AppOpenHandler
+    @Environment(AppOpenHandler.self) private var openHandler
 
     let initialURLs: [URL]
     let initialElements: [CMCanvasElement]?
@@ -134,7 +134,7 @@ struct ContentView: View {
                 urlsToInsert = initialURLs
             }
         }
-        .onReceive(openHandler.$importedElements) { value in
+        .onChange(of: openHandler.importedElements) { _, value in
             if let els = value {
                 elementsToLoad = els
                 // Clear the open handler value to avoid repeated loads
@@ -218,5 +218,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView(initialURLs: [], initialElements: nil)
-        .environmentObject(AppOpenHandler())
+        .environment(AppOpenHandler())
 }

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -16,15 +16,15 @@ struct ContentView: View {
 
     @State private var activeTool: CanvasTool = .pointer
     @State private var showingSettings = false
-    @State private var urlsToInsert: [URL]? = nil
+    @State private var urlsToInsert: [URL]?
     
     // Settings
     @State private var showGrid = true
     @State private var toolbarSide: ToolbarSide = .left
     @State private var canvasColor: Color = .white
     
-    @State private var snapshotToken: UUID? = nil
-    @State private var elementsToLoad: [CMCanvasElement]? = nil
+    @State private var snapshotToken: UUID?
+    @State private var elementsToLoad: [CMCanvasElement]?
     @State private var showingExporter = false
     @State private var exportDocument = BoardExportDocument(elements: [])
 
@@ -33,10 +33,10 @@ struct ContentView: View {
     @State private var undoTrigger: UUID?
     @State private var redoTrigger: UUID?
 
-    @State private var importerMode: ImporterMode? = nil
+    @State private var importerMode: ImporterMode?
     @State private var importerPresented = false
     /// Latched copy so the result handler can read it even after the binding clears importerMode
-    @State private var lastImporterMode: ImporterMode? = nil
+    @State private var lastImporterMode: ImporterMode?
     private enum ImporterMode { case images, board }
 
     var body: some View {

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -34,6 +34,7 @@ struct ContentView: View {
     @State private var redoTrigger: UUID?
 
     @State private var importerMode: ImporterMode? = nil
+    @State private var importerPresented = false
     /// Latched copy so the result handler can read it even after the binding clears importerMode
     @State private var lastImporterMode: ImporterMode? = nil
     private enum ImporterMode { case images, board }
@@ -94,11 +95,14 @@ struct ContentView: View {
                 print("Export share failed: ", error.localizedDescription)
             }
         }
+        .onChange(of: importerMode) { _, newMode in
+            importerPresented = (newMode != nil)
+        }
+        .onChange(of: importerPresented) { _, presented in
+            if !presented { importerMode = nil }
+        }
         .fileImporter(
-            isPresented: Binding(
-                get: { importerMode != nil },
-                set: { newValue in if !newValue { importerMode = nil } }
-            ),
+            isPresented: $importerPresented,
             allowedContentTypes: (importerMode == .images) ? [.image, .gif] : [.refboard],
             allowsMultipleSelection: importerMode == .images
         ) { result in

--- a/SuperCoolArtReferenceTool/App/RootView.swift
+++ b/SuperCoolArtReferenceTool/App/RootView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RootView: View {
-    @EnvironmentObject private var openHandler: AppOpenHandler
+    @Environment(AppOpenHandler.self) private var openHandler
 
     @State private var showCanvas = false
     @State private var initialURLs: [URL] = []
@@ -23,7 +23,7 @@ struct RootView: View {
                 initialURLs = urls
                 showCanvas = true
             })
-            .onReceive(openHandler.$importedElements) { value in
+            .onChange(of: openHandler.importedElements) { _, value in
                 if let value {
                     initialURLs = []
                     initialElements = value
@@ -36,5 +36,5 @@ struct RootView: View {
 
 #Preview {
     RootView()
-        .environmentObject(AppOpenHandler())
+        .environment(AppOpenHandler())
 }

--- a/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
+++ b/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 @main
 struct SuperCoolArtReferenceToolApp: App {
-    @StateObject private var openHandler = AppOpenHandler()
+    @State private var openHandler = AppOpenHandler()
     var body: some Scene {
         WindowGroup {
             RootView()
-                .environmentObject(openHandler)
+                .environment(openHandler)
                 .onOpenURL { url in
                     Task {
                         guard url.pathExtension.lowercased() == "refboard" else { return }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/AppOpenHandler.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/AppOpenHandler.swift
@@ -5,5 +5,5 @@ import Foundation
 @Observable
 @MainActor
 final class AppOpenHandler {
-    var importedElements: [CMCanvasElement]? = nil
+    var importedElements: [CMCanvasElement]?
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/AppOpenHandler.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/AppOpenHandler.swift
@@ -1,9 +1,9 @@
 import Foundation
-import SwiftUI
-import Combine
 
-/// A lightweight environment object to deliver imported elements from the app open handler
-/// down to ContentView, which can then route them to the canvas view.
-final class AppOpenHandler: ObservableObject {
-    @Published var importedElements: [CMCanvasElement]? = nil
+/// Lightweight observable that delivers imported elements from the app open
+/// handler down to ContentView, which can then route them to the canvas view.
+@Observable
+@MainActor
+final class AppOpenHandler {
+    var importedElements: [CMCanvasElement]? = nil
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -14,6 +14,7 @@ struct BoardCanvasView: View {
 
     // Gesture state
     @State private var dragStartOffset: CGSize? = nil
+    @State private var twoFingerPanStartOffset: CGSize? = nil
     @State private var zoomStartScale: CGFloat? = nil
     @State private var isInteracting: Bool = false
     @State private var interactionEndTask: Task<Void, Never>? = nil
@@ -381,6 +382,25 @@ struct BoardCanvasView: View {
                         zoomStartScale = nil
                         endInteraction()
                     }
+            )
+            .background(
+                TwoFingerPanView { phase, translation in
+                    switch phase {
+                    case .began:
+                        startInteraction()
+                        twoFingerPanStartOffset = offset
+                    case .changed:
+                        let start = twoFingerPanStartOffset ?? offset
+                        offset = CGSize(
+                            width: start.width + translation.width,
+                            height: start.height + translation.height
+                        )
+                        scheduleRefreshVisibleElements()
+                    case .ended:
+                        twoFingerPanStartOffset = nil
+                        endInteraction()
+                    }
+                }
             )
         }
     }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -247,6 +247,7 @@ struct BoardCanvasView: View {
             .onChange(of: elementsToLoad) { oldValue, newValue in
                 if let els = newValue {
                     applyElements(els)
+                    commandHistory.clear()
                     // Clear the binding after applying
                     DispatchQueue.main.async {
                         elementsToLoad = nil

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -67,7 +67,8 @@ struct BoardCanvasView: View {
     private let onSnapshot: (([CMCanvasElement]) -> Void)?
     @Binding private var elementsToLoad: [CMCanvasElement]?
 
-    init(activeTool: Binding<CanvasTool> = .constant(.pointer), externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), canvasColor: Binding<Color> = .constant(.white), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), commandHistory: CanvasCommandHistory = CanvasCommandHistory(), undoTrigger: Binding<UUID?> = .constant(nil), redoTrigger: Binding<UUID?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement]) -> Void)? = nil) {
+    @MainActor
+    init(activeTool: Binding<CanvasTool> = .constant(.pointer), externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), canvasColor: Binding<Color> = .constant(.white), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), commandHistory: CanvasCommandHistory, undoTrigger: Binding<UUID?> = .constant(nil), redoTrigger: Binding<UUID?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement]) -> Void)? = nil) {
         let store = LocalBoardStore()
         self._canvasStore = State(initialValue: store)
         self._activeTool = activeTool
@@ -1238,5 +1239,5 @@ extension NSItemProvider {
 }
 
 #Preview {
-    BoardCanvasView()
+    BoardCanvasView(commandHistory: CanvasCommandHistory())
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -384,25 +384,7 @@ struct BoardCanvasView: View {
                         endInteraction()
                     }
             )
-            .background(
-                TwoFingerPanView { phase, translation in
-                    switch phase {
-                    case .began:
-                        startInteraction()
-                        twoFingerPanStartOffset = offset
-                    case .changed:
-                        let start = twoFingerPanStartOffset ?? offset
-                        offset = CGSize(
-                            width: start.width + translation.width,
-                            height: start.height + translation.height
-                        )
-                        scheduleRefreshVisibleElements()
-                    case .ended:
-                        twoFingerPanStartOffset = nil
-                        endInteraction()
-                    }
-                }
-            )
+            .background(TwoFingerPanView(onPan: handleTwoFingerPan))
         }
     }
 
@@ -424,6 +406,22 @@ struct BoardCanvasView: View {
         interactionEndTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 150_000_000)
             isInteracting = false
+        }
+    }
+
+    private func handleTwoFingerPan(phase: TwoFingerPanView.Phase, translation: CGSize) {
+        switch phase {
+        case .began:
+            startInteraction()
+            twoFingerPanStartOffset = offset
+        case .changed:
+            let start = twoFingerPanStartOffset ?? offset
+            offset = CGSize(width: start.width + translation.width,
+                            height: start.height + translation.height)
+            scheduleRefreshVisibleElements()
+        case .ended:
+            twoFingerPanStartOffset = nil
+            endInteraction()
         }
     }
 

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
@@ -20,6 +20,7 @@ enum CanvasCommand {
 
 /// Tracks performed commands for undo/redo support.
 @Observable
+@MainActor
 final class CanvasCommandHistory {
     private(set) var undoStack: [CanvasCommand] = []
     private(set) var redoStack: [CanvasCommand] = []

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCommandHistory.swift
@@ -43,4 +43,9 @@ final class CanvasCommandHistory {
         undoStack.append(command)
         return command
     }
+
+    func clear() {
+        undoStack.removeAll()
+        redoStack.removeAll()
+    }
 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasOverlayLayout.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasOverlayLayout.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Positions the canvas toolbar (vertically centered) and the settings button
+/// (bottom corner) on the left or right edge of the canvas, based on the
+/// user's toolbar-side preference.
+struct CanvasOverlayLayout: View {
+    let side: ToolbarSide
+    @Binding var activeTool: CanvasTool
+    let onUndo: () -> Void
+    let onRedo: () -> Void
+    let onAddItem: () -> Void
+    let onSettings: () -> Void
+
+    var body: some View {
+        let edge: Edge.Set = (side == .left) ? .leading : .trailing
+        let frameAlignment: Alignment = (side == .left) ? .leading : .trailing
+
+        Group {
+            CanvasToolbar(
+                activeTool: $activeTool,
+                onUndo: onUndo,
+                onRedo: onRedo,
+                onAddItem: onAddItem
+            )
+            .padding(edge, 16)
+            .frame(maxWidth: .infinity, alignment: frameAlignment)
+
+            VStack {
+                Spacer()
+                CanvasSettingsButton(onTap: onSettings)
+                    .padding(edge, 16)
+                    .padding(.bottom, 16)
+                    .frame(maxWidth: .infinity, alignment: frameAlignment)
+            }
+        }
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSelectionState.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSelectionState.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 @Observable
+@MainActor
 final class CanvasSelectionState {
     var selectedIDs: Set<UUID> = []
     /// World-space offset being applied during an active drag-move

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasSettingsView.swift
@@ -16,7 +16,7 @@ struct CanvasSettingsView: View {
     @Binding var canvasColor: Color
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section("Canvas") {
                     HStack {

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasTool.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasTool.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Available tools selectable from the canvas toolbar.
+enum CanvasTool: Equatable {
+    case pointer
+    case group
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/TwoFingerPanView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/TwoFingerPanView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import UIKit
+
+/// Installs a two-finger UIPanGestureRecognizer on the nearest ancestor UIView
+/// in the SwiftUI host hierarchy. The recognizer observes touches in the canvas
+/// area without consuming them, so SwiftUI's single-finger DragGesture,
+/// SpatialTapGesture, and MagnificationGesture continue to receive their touches.
+struct TwoFingerPanView: UIViewRepresentable {
+    enum Phase { case began, changed, ended }
+
+    /// Phase + cumulative translation in screen points since `began`.
+    let onPan: (Phase, CGSize) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(onPan: onPan) }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = InstallerView()
+        view.coordinator = context.coordinator
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.onPan = onPan
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onPan: (Phase, CGSize) -> Void
+        let recognizer: UIPanGestureRecognizer
+
+        init(onPan: @escaping (Phase, CGSize) -> Void) {
+            self.onPan = onPan
+            self.recognizer = UIPanGestureRecognizer()
+            super.init()
+            recognizer.minimumNumberOfTouches = 2
+            recognizer.maximumNumberOfTouches = 2
+            recognizer.cancelsTouchesInView = false
+            recognizer.delaysTouchesBegan = false
+            recognizer.delaysTouchesEnded = false
+            recognizer.delegate = self
+            recognizer.addTarget(self, action: #selector(handle(_:)))
+        }
+
+        @objc func handle(_ recognizer: UIPanGestureRecognizer) {
+            let t = recognizer.translation(in: recognizer.view)
+            let delta = CGSize(width: t.x, height: t.y)
+            switch recognizer.state {
+            case .began: onPan(.began, delta)
+            case .changed: onPan(.changed, delta)
+            case .ended, .cancelled, .failed: onPan(.ended, delta)
+            default: break
+            }
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+
+    /// Non-interactive marker view; once mounted, walks up to find a hosting
+    /// ancestor and installs the recognizer there so it sees all canvas touches.
+    private final class InstallerView: UIView {
+        weak var coordinator: Coordinator?
+        private weak var installedHost: UIView?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            installIfNeeded()
+        }
+
+        override func didMoveToSuperview() {
+            super.didMoveToSuperview()
+            installIfNeeded()
+        }
+
+        private func installIfNeeded() {
+            guard let coordinator else { return }
+            guard window != nil else { return }
+            let host = hostingAncestor() ?? superview
+            guard let host, host !== installedHost else { return }
+            // Move recognizer to the new host (in case of view recycling)
+            coordinator.recognizer.view?.removeGestureRecognizer(coordinator.recognizer)
+            host.addGestureRecognizer(coordinator.recognizer)
+            installedHost = host
+        }
+
+        /// Walk up the responder chain to the first UIViewController's root view —
+        /// that's the SwiftUI hosting view, ancestor of all canvas content.
+        private func hostingAncestor() -> UIView? {
+            var responder: UIResponder? = self.next
+            while let r = responder {
+                if let vc = r as? UIViewController { return vc.view }
+                responder = r.next
+            }
+            return nil
+        }
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/TwoFingerPanView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/TwoFingerPanView.swift
@@ -24,6 +24,10 @@ struct TwoFingerPanView: UIViewRepresentable {
         context.coordinator.onPan = onPan
     }
 
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
         var onPan: (Phase, CGSize) -> Void
         let recognizer: UIPanGestureRecognizer
@@ -55,6 +59,15 @@ struct TwoFingerPanView: UIViewRepresentable {
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                                shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
             true
+        }
+
+        /// Remove the recognizer from its host and break retention so the coordinator
+        /// and onPan closure can be released when the representable is dismantled.
+        func detach() {
+            recognizer.view?.removeGestureRecognizer(recognizer)
+            recognizer.removeTarget(self, action: #selector(handle(_:)))
+            recognizer.delegate = nil
+            onPan = { _, _ in }
         }
     }
 

--- a/SuperCoolArtReferenceTool/Features/FilePicker/FilePickerView.swift
+++ b/SuperCoolArtReferenceTool/Features/FilePicker/FilePickerView.swift
@@ -66,8 +66,7 @@ struct FilePickerView: View {
                     .foregroundStyle(DesignSystem.Colors.primary)
                     .padding(.horizontal, 32)
                     .padding(.vertical, 12)
-                    .background(DesignSystem.Colors.tertiary)
-                    .cornerRadius(8)
+                    .background(DesignSystem.Colors.tertiary, in: .rect(cornerRadius: 8))
             }
             .buttonStyle(.plain)
         }

--- a/SuperCoolArtReferenceTool/Features/HUD/CanvasToolbar.swift
+++ b/SuperCoolArtReferenceTool/Features/HUD/CanvasToolbar.swift
@@ -116,12 +116,6 @@ private struct ToolbarButton: View {
     }
 }
 
-/// Available canvas tools
-enum CanvasTool: Equatable {
-    case pointer
-    case group
-}
-
 // MARK: - Preview
 
 #Preview("Canvas Toolbar") {

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -87,6 +87,16 @@ Three simultaneous gestures are attached to the canvas ZStack:
 - Preserves world position at anchor point during zoom
 - Gesture state: `zoomStartScale` stores scale at gesture begin
 
+**Two-Finger Pan (UIKit Bridge):**
+
+**File:** `TwoFingerPanView.swift`
+
+- Provides always-available two-finger panning regardless of active tool so Group-tool marquee doesn't block canvas navigation
+- Implemented as a `UIViewRepresentable` that installs a `UIPanGestureRecognizer` (min/max touches = 2) on the nearest `UIViewController.view` ancestor by walking the `responder.next` chain
+- Recognizer config: `cancelsTouchesInView = false`, `delaysTouchesBegan/Ended = false`, delegate returns `true` for `shouldRecognizeSimultaneouslyWith` so SwiftUI gestures still observe touches
+- Attached via `.background(TwoFingerPanView(onPan:))` on the canvas; routed through `handleTwoFingerPan(phase:translation:)` which updates `offset` relative to a cached `twoFingerPanStartOffset`
+- Works with pinch-zoom simultaneously; single-finger tool gestures are unaffected
+
 **Known Limitation:**
 - Zoom anchors around view center instead of pinch location
 - A `PinchGestureView.swift` component was created to capture UIKit pinch gestures with precise anchor points
@@ -167,20 +177,27 @@ Lightweight root view that routes between the landing screen and the canvas.
 
 - Shows `FilePickerView` on launch; transitions to `ContentView` once files are selected
 - Uses `@State private var showCanvas: Bool` to control which screen is displayed
-- Observes `openHandler.$importedElements` so `.refboard` cold launches navigate directly to canvas
+- Observes `openHandler.importedElements` via `onChange(of:)` so `.refboard` cold launches navigate directly to canvas
 - `ContentView` receives selected URLs as a `let initialURLs: [URL]` (not a binding)
+
+**Observable App Open Handler:**
+
+- `AppOpenHandler` is an `@Observable @MainActor final class` (migrated from `ObservableObject` + `@Published`)
+- Injected through the environment at the app root via `.environment(openHandler)` and read via `@Environment(AppOpenHandler.self)` in `RootView` / `ContentView`
 
 **ContentView:**
 - Hosts `BoardCanvasView` in a `ZStack`
-- Overlays `CanvasToolbar` (centered left) and `CanvasSettingsButton` (bottom-left)
+- Overlays `CanvasOverlayLayout` which places `CanvasToolbar` (centered) and `CanvasSettingsButton` (bottom corner) on the configured side
 - Manages `@State private var urlsToInsert: [URL]?` binding for file picker integration
 - On `.onAppear`, forwards `initialURLs` to `urlsToInsert` for the canvas to consume
 - Presents `.fileImporter` when toolbar "Add Item" is tapped
 - Presents `.sheet` with `CanvasSettingsView` when settings button is tapped
 
 **File Picker Integration:**
-- Toolbar's `onAddItem` callback sets `importerMode = .images`
-- `.fileImporter` allows multiple selection of `.image` and `.gif` types
+- Toolbar's `onAddItem` callback sets `importerMode = .images` (board import sets `.board`)
+- `.fileImporter` presentation is driven by `@State private var importerPresented: Bool`; changes to `importerMode` toggle `importerPresented` via `.onChange(of:)`, and clearing `importerPresented` resets `importerMode` — avoids inline `Binding(get:set:)` closures
+- A latched `lastImporterMode` lets the result handler know which mode was active even after the mode binding clears
+- `.fileImporter` allows multiple selection of `.image` and `.gif` types (images mode) or a single `.refboard` (board mode)
 - Selected URLs are passed to `BoardCanvasView` via `externalInsertURLs` binding
 - `BoardCanvasView` watches binding with `.onChange`, calls `insertImagesAtCenter()`
 - Binding is cleared after processing to reset state
@@ -218,7 +235,7 @@ The Canvas Toolbar provides tool selection and canvas actions through a persiste
 
 - `CanvasToolbar`: Main toolbar view component
 - `ToolbarButton`: Private reusable button component with active state support
-- `CanvasTool`: Enum defining available tools (`.pointer`, `.group`)
+- `CanvasTool`: Enum defining available tools (`.pointer`, `.group`) — lives in its own file `CanvasTool.swift`
 
 **Visual Design:**
 
@@ -455,10 +472,11 @@ ContentView                  — triggers undo/redo from toolbar
 
 **History Management:**
 
-- `CanvasCommandHistory` is an `@Observable` class owned as `@State` in `ContentView` and passed to `BoardCanvasView`
+- `CanvasCommandHistory` is an `@Observable @MainActor` class owned as `@State` in `ContentView` and passed to `BoardCanvasView` (required init parameter, no default)
 - `push(_:)` — appends to undo stack, clears redo stack
 - `popUndo()` / `popRedo()` — moves commands between stacks
 - `canUndo` / `canRedo` — computed properties for UI state
+- `clear()` — wipes both undo and redo stacks; called after a board import so stale commands from the previous board can't resurrect removed assets via redo
 
 **Integration:**
 
@@ -539,11 +557,12 @@ A standalone settings button positioned dynamically at the bottom corner of the 
 
 **Dynamic UI Layout:**
 
-`ContentView` implements two layout variants:
-- `leftSideLayout` - Toolbar + settings on left (default)
-- `rightSideLayout` - Toolbar + settings on right (mirrored)
-- Both maintain 16pt padding from edges
-- Settings button always positioned with toolbar for consistency
+**File:** `CanvasOverlayLayout.swift`
+
+A single reusable view that positions both the `CanvasToolbar` (vertically centered) and the `CanvasSettingsButton` (bottom corner) on the configured side:
+- Takes `side: ToolbarSide` and derives `edge: Edge.Set` and `frameAlignment: Alignment`
+- `ContentView` instantiates `CanvasOverlayLayout(side: toolbarSide, ...)` once instead of branching between `leftSideLayout`/`rightSideLayout` computed properties
+- Both elements maintain 16pt padding from edges
 
 **Visual Styling:**
 

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -96,6 +96,7 @@ Three simultaneous gestures are attached to the canvas ZStack:
 - Recognizer config: `cancelsTouchesInView = false`, `delaysTouchesBegan/Ended = false`, delegate returns `true` for `shouldRecognizeSimultaneouslyWith` so SwiftUI gestures still observe touches
 - Attached via `.background(TwoFingerPanView(onPan:))` on the canvas; routed through `handleTwoFingerPan(phase:translation:)` which updates `offset` relative to a cached `twoFingerPanStartOffset`
 - Works with pinch-zoom simultaneously; single-finger tool gestures are unaffected
+- Teardown: `dismantleUIView(_:coordinator:)` calls `Coordinator.detach()` to remove the recognizer from its host view, clear target/delegate, and replace `onPan` with a no-op — prevents duplicate recognizers and retention cycles if the canvas remounts (e.g. `RootView` toggling `showCanvas`)
 
 **Known Limitation:**
 - Zoom anchors around view center instead of pinch location


### PR DESCRIPTION
## Summary
- Fix redo restoring stale assets after a board import by clearing undo/redo history on import (adds `CanvasCommandHistory.clear()`).
- Enable always-available two-finger pan on the canvas via a `UIViewRepresentable` bridge (`TwoFingerPanView`) so the Group tool's marquee no longer blocks navigation.
- Modernize data flow: migrate `AppOpenHandler` to `@Observable @MainActor`, switch to `@Environment`/`@State`, mark `CanvasSelectionState` and `CanvasCommandHistory` `@MainActor`.
- Replace deprecated SwiftUI APIs (`NavigationView` → `NavigationStack`, `.cornerRadius` on background → `.background(_:in: .rect(cornerRadius:))`).
- Drop inline `Binding(get:set:)` for the unified file importer in favor of `@State` + `.onChange(of:)`.
- Extract `CanvasOverlayLayout` (replaces `leftSideLayout`/`rightSideLayout` computed props) and pull `CanvasTool` into its own file.
- Update `architecture-frontend.md` to reflect the above.

Closes #36
Closes #37

## Test plan
- [ ] Launch app, land on FilePicker, drop images → enters canvas
- [ ] Pan/zoom with one finger and pinch work as before
- [ ] Two-finger drag pans the canvas while in both Pointer and Group tools
- [ ] Group tool marquee still works with single finger
- [ ] Import a `.refboard`, perform actions, undo, import another board — redo is disabled (no stale assets resurrect)
- [ ] Undo/redo buttons still work within a single board session
- [ ] Settings sheet opens, toolbar side toggle mirrors toolbar + settings button correctly
- [ ] Add Item from toolbar opens image importer; Import button opens board importer
- [ ] Export produces a working `.refboard`