### PR TITLE
Address Copilot PR feedback: authoritative snapshots, MainActor dragB…

### DIFF
--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -280,6 +280,7 @@ struct BoardCanvasView: View {
                 if let els = newValue {
                     applyElements(els)
                     commandHistory.clear()
+                    selection.clearSelection()
                     // Clear the binding after applying
                     DispatchQueue.main.async {
                         elementsToLoad = nil
@@ -889,12 +890,30 @@ struct BoardCanvasView: View {
         Task { @MainActor in
             let elementsByID = await store.elements(for: Array(placedByID.keys))
             let snapshots: [PlacedElementSnapshot] = placedByID.map { id, placed in
-                let element = elementsByID[id] ?? fallbackElement(for: placed)
+                let authElement = elementsByID[id]
+                let element = authElement ?? fallbackElement(for: placed)
+                let worldRect: CGRect
+                let zIndex: Int
+
+                if let authElement {
+                    let bounds = authElement.header.bounds
+                    worldRect = CGRect(
+                        x: CGFloat(bounds.origin.x),
+                        y: CGFloat(bounds.origin.y),
+                        width: CGFloat(bounds.size.x),
+                        height: CGFloat(bounds.size.y)
+                    )
+                    zIndex = authElement.header.zIndex
+                } else {
+                    worldRect = placed.worldRect
+                    zIndex = placed.zIndex
+                }
+
                 return PlacedElementSnapshot(
                     id: id,
                     url: placed.url,
-                    worldRect: placed.worldRect,
-                    zIndex: placed.zIndex,
+                    worldRect: worldRect,
+                    zIndex: zIndex,
                     element: element
                 )
             }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasToolBehavior.swift
@@ -17,6 +17,7 @@ struct HitTestItem {
 
 protocol CanvasToolBehavior {
     /// Synchronous mode decision using in-memory placed images (no store round-trip).
+    @MainActor
     func dragBegan(
         worldStart: CGPoint,
         items: [HitTestItem],
@@ -39,6 +40,7 @@ protocol CanvasToolBehavior {
 }
 
 struct PointerToolBehavior: CanvasToolBehavior {
+    @MainActor
     func dragBegan(
         worldStart: CGPoint,
         items: [HitTestItem],
@@ -76,6 +78,7 @@ struct PointerToolBehavior: CanvasToolBehavior {
 }
 
 struct GroupToolBehavior: CanvasToolBehavior {
+    @MainActor
     func dragBegan(worldStart: CGPoint, items: [HitTestItem], selection: CanvasSelectionState) -> DragMode {
         if let hit = PointerToolBehavior.topmostItem(at: worldStart, in: items) {
             if !selection.selectedIDs.contains(hit.id) {


### PR DESCRIPTION
…egan, clear selection on import

- deleteSelection() now derives worldRect/zIndex from the store element header when available, falling back to the view cache only on miss.
- Mark dragBegan as @MainActor in protocol + implementations so CanvasSelectionState access is isolation-correct.
- Clear selection state alongside command history on board import to avoid stale selectedIDs referencing removed elements.