### PR TITLE
Persistence diagnostics: signposts, ZIP probe, file-provider tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ xcodebuild -project SuperCoolArtReferenceTool.xcodeproj \
 open SuperCoolArtReferenceTool.xcodeproj
 ```
 
-No package managers (no SPM, CocoaPods, or Carthage). No test targets currently exist.
+SwiftPM is used for one dependency (`ZIPFoundation`, added via Xcode's Package Dependencies). No CocoaPods or Carthage. No test targets currently exist.
 
 ## Architecture
 
@@ -83,6 +83,5 @@ Document only finalized implementations, not speculative architecture.
 
 ## Known Issues
 
-- `.refboard` UTType declared in code but not in Info.plist — produces runtime warning. See `App/InfoPlist_Refboard_Additions.md`.
 - File loading logic duplicated between `BoardCanvasView.swift` and `InsertFileControl.swift`.
 - Pointer and group tools in toolbar are not yet connected to canvas behavior.

--- a/SuperCoolArtReferenceTool/App/BoardArchiver.swift
+++ b/SuperCoolArtReferenceTool/App/BoardArchiver.swift
@@ -364,7 +364,7 @@ enum BoardArchiver {
             case .corruptedFile:
                 return "This board file is incomplete or damaged. It may have been interrupted while saving."
             case .ioFailure:
-                return "The board file couldn't be read. Check that it's available and try again."
+                return "The board file couldn't be accessed. Check that it's available and try again."
             }
         }
 

--- a/SuperCoolArtReferenceTool/App/BoardArchiver.swift
+++ b/SuperCoolArtReferenceTool/App/BoardArchiver.swift
@@ -307,9 +307,20 @@ enum BoardArchiver {
         }
     }
 
-    enum ImportError: Error {
+    enum ImportError: LocalizedError {
         case unsupportedFileExtension
         case corruptedFile
         case ioFailure
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedFileExtension:
+                return "Only .refboard files can be opened."
+            case .corruptedFile:
+                return "This board file is incomplete or damaged. It may have been interrupted while saving."
+            case .ioFailure:
+                return "The board file couldn't be read. Check that it's available and try again."
+            }
+        }
     }
 }

--- a/SuperCoolArtReferenceTool/App/BoardArchiver.swift
+++ b/SuperCoolArtReferenceTool/App/BoardArchiver.swift
@@ -23,12 +23,12 @@ enum BoardArchiver {
     /// - Returns: An array of `CMCanvasElement` decoded from the package's `manifest.json`. The array may be empty if the manifest contains no elements.
     static func importElements(from url: URL, copyAssetsToAppSupport: Bool) throws -> [CMCanvasElement] {
         guard url.pathExtension.lowercased() == "refboard" else {
-            throw ImportError.unsupportedFileExtension
+            throw ArchiverError.unsupportedFileExtension
         }
 
         let signposter = OSSignposter.archiver
         let signpostID = signposter.makeSignpostID()
-        let intervalState = signposter.beginInterval("import", id: signpostID, "provider: \(fileProviderDescription(for: url))")
+        let intervalState = signposter.beginInterval("import", id: signpostID, "provider: \(fileProviderDescription(for: url), privacy: .public)")
         defer { signposter.endInterval("import", intervalState) }
 
         let accessGranted = url.startAccessingSecurityScopedResource()
@@ -37,7 +37,7 @@ enum BoardArchiver {
         // Check if it's a directory package or a single-file ZIP
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) else {
-            throw ImportError.corruptedFile(failingEntryPath: nil)
+            throw ArchiverError.corruptedFile(failingEntryPath: nil)
         }
         if isDir.boolValue {
             return try importFromPackage(url: url, copyAssetsToAppSupport: copyAssetsToAppSupport)
@@ -62,7 +62,7 @@ enum BoardArchiver {
         } else if let firstDir = firstDirectory(in: tempDir) {
             packageURL = firstDir
         } else {
-            throw ImportError.corruptedFile(failingEntryPath: nil)
+            throw ArchiverError.corruptedFile(failingEntryPath: nil)
         }
 
         return try importFromPackage(url: packageURL, copyAssetsToAppSupport: copyAssetsToAppSupport)
@@ -72,7 +72,7 @@ enum BoardArchiver {
         // Ensure it's a directory package
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
-            throw ImportError.corruptedFile(failingEntryPath: nil)
+            throw ArchiverError.corruptedFile(failingEntryPath: nil)
         }
 
         // Load and decode the manifest
@@ -157,7 +157,7 @@ enum BoardArchiver {
     nonisolated static func export(elements: [CMCanvasElement], to destination: URL) throws -> URL {
         let signposter = OSSignposter.archiver
         let signpostID = signposter.makeSignpostID()
-        let intervalState = signposter.beginInterval("export", id: signpostID, "provider: \(fileProviderDescription(for: destination)), elements: \(elements.count)")
+        let intervalState = signposter.beginInterval("export", id: signpostID, "provider: \(fileProviderDescription(for: destination), privacy: .public), elements: \(elements.count, privacy: .public)")
         defer { signposter.endInterval("export", intervalState) }
 
         let fm = FileManager.default
@@ -174,11 +174,11 @@ enum BoardArchiver {
             // recursion. One-shot retry as `.create`; bail if that still fails.
             try fm.removeItem(at: destination)
             guard let fresh = Archive(url: destination, accessMode: .create) else {
-                throw ImportError.ioFailure(underlying: nil)
+                throw ArchiverError.ioFailure(underlying: nil)
             }
             archive = fresh
         } else {
-            throw ImportError.ioFailure(underlying: nil)
+            throw ArchiverError.ioFailure(underlying: nil)
         }
 
         // Compute the desired state: manifest elements + set of asset paths that should exist.
@@ -241,22 +241,22 @@ enum BoardArchiver {
     private static func unzipItem(at sourceURL: URL, to destinationURL: URL) throws {
         guard let archive = Archive(url: sourceURL, accessMode: .read) else {
             let probe = probeZipTail(sourceURL)
-            Logger.archiver.error("Archive open failed for \(sourceURL.lastPathComponent, privacy: .private). \(probe, privacy: .public)")
-            throw ImportError.ioFailure(underlying: nil)
+            Logger.archiver.logArchiveOpenFailed(url: sourceURL, probe: probe)
+            throw ArchiverError.ioFailure(underlying: nil)
         }
 
         let fm = FileManager.default
         let destinationRoot = destinationURL.standardizedFileURL
         for entry in archive {
             guard let destURL = sanitizedArchiveEntryURL(entry.path, destinationRoot: destinationRoot) else {
-                throw ImportError.corruptedFile(failingEntryPath: entry.path)
+                throw ArchiverError.corruptedFile(failingEntryPath: entry.path)
             }
             if entry.type == .directory {
                 try fm.createDirectory(at: destURL, withIntermediateDirectories: true)
                 continue
             }
             if entry.type != .file {
-                throw ImportError.corruptedFile(failingEntryPath: entry.path)
+                throw ArchiverError.corruptedFile(failingEntryPath: entry.path)
             }
             try fm.createDirectory(at: destURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             _ = try archive.extract(entry, to: destURL)
@@ -351,7 +351,7 @@ enum BoardArchiver {
         }
     }
 
-    enum ImportError: LocalizedError {
+    enum ArchiverError: LocalizedError {
         case unsupportedFileExtension
         case corruptedFile(failingEntryPath: String?)
         case ioFailure(underlying: Error?)

--- a/SuperCoolArtReferenceTool/App/BoardArchiver.swift
+++ b/SuperCoolArtReferenceTool/App/BoardArchiver.swift
@@ -8,6 +8,7 @@
 import Foundation
 import ZIPFoundation
 import simd
+import os
 
 /// Handles importing and exporting reference board data as single-file `.refboard` ZIPs
 /// that contain a package layout (manifest + assets).
@@ -25,13 +26,18 @@ enum BoardArchiver {
             throw ImportError.unsupportedFileExtension
         }
 
+        let signposter = OSSignposter.archiver
+        let signpostID = signposter.makeSignpostID()
+        let intervalState = signposter.beginInterval("import", id: signpostID, "provider: \(fileProviderDescription(for: url))")
+        defer { signposter.endInterval("import", intervalState) }
+
         let accessGranted = url.startAccessingSecurityScopedResource()
         defer { if accessGranted { url.stopAccessingSecurityScopedResource() } }
 
         // Check if it's a directory package or a single-file ZIP
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) else {
-            throw ImportError.corruptedFile
+            throw ImportError.corruptedFile(failingEntryPath: nil)
         }
         if isDir.boolValue {
             return try importFromPackage(url: url, copyAssetsToAppSupport: copyAssetsToAppSupport)
@@ -56,7 +62,7 @@ enum BoardArchiver {
         } else if let firstDir = firstDirectory(in: tempDir) {
             packageURL = firstDir
         } else {
-            throw ImportError.corruptedFile
+            throw ImportError.corruptedFile(failingEntryPath: nil)
         }
 
         return try importFromPackage(url: packageURL, copyAssetsToAppSupport: copyAssetsToAppSupport)
@@ -66,7 +72,7 @@ enum BoardArchiver {
         // Ensure it's a directory package
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
-            throw ImportError.corruptedFile
+            throw ImportError.corruptedFile(failingEntryPath: nil)
         }
 
         // Load and decode the manifest
@@ -149,6 +155,11 @@ enum BoardArchiver {
     /// `nonisolated` so autosave can run this on a utility-priority detached task without
     /// hopping to the main actor.
     nonisolated static func export(elements: [CMCanvasElement], to destination: URL) throws -> URL {
+        let signposter = OSSignposter.archiver
+        let signpostID = signposter.makeSignpostID()
+        let intervalState = signposter.beginInterval("export", id: signpostID, "provider: \(fileProviderDescription(for: destination)), elements: \(elements.count)")
+        defer { signposter.endInterval("export", intervalState) }
+
         let fm = FileManager.default
         try fm.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
 
@@ -163,11 +174,11 @@ enum BoardArchiver {
             // recursion. One-shot retry as `.create`; bail if that still fails.
             try fm.removeItem(at: destination)
             guard let fresh = Archive(url: destination, accessMode: .create) else {
-                throw ImportError.ioFailure
+                throw ImportError.ioFailure(underlying: nil)
             }
             archive = fresh
         } else {
-            throw ImportError.ioFailure
+            throw ImportError.ioFailure(underlying: nil)
         }
 
         // Compute the desired state: manifest elements + set of asset paths that should exist.
@@ -229,25 +240,58 @@ enum BoardArchiver {
 
     private static func unzipItem(at sourceURL: URL, to destinationURL: URL) throws {
         guard let archive = Archive(url: sourceURL, accessMode: .read) else {
-            throw ImportError.ioFailure
+            let probe = probeZipTail(sourceURL)
+            Logger.archiver.error("Archive open failed for \(sourceURL.lastPathComponent, privacy: .public). \(probe, privacy: .public)")
+            throw ImportError.ioFailure(underlying: nil)
         }
 
         let fm = FileManager.default
         let destinationRoot = destinationURL.standardizedFileURL
         for entry in archive {
             guard let destURL = sanitizedArchiveEntryURL(entry.path, destinationRoot: destinationRoot) else {
-                throw ImportError.corruptedFile
+                throw ImportError.corruptedFile(failingEntryPath: entry.path)
             }
             if entry.type == .directory {
                 try fm.createDirectory(at: destURL, withIntermediateDirectories: true)
                 continue
             }
             if entry.type != .file {
-                throw ImportError.corruptedFile
+                throw ImportError.corruptedFile(failingEntryPath: entry.path)
             }
             try fm.createDirectory(at: destURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             _ = try archive.extract(entry, to: destURL)
         }
+    }
+
+    /// Distinguishes "killed mid-write" (no End-of-Central-Directory signature in the
+    /// trailing bytes) from "structurally valid but unreadable" so log lines can point
+    /// at the right cause.
+    private static func probeZipTail(_ url: URL) -> String {
+        let fm = FileManager.default
+        guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? UInt64 else {
+            return "ZIP probe: cannot stat file"
+        }
+        guard size > 0 else { return "ZIP probe: empty file" }
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return "ZIP probe: cannot open (size=\(size))"
+        }
+        defer { try? handle.close() }
+        let probeSize: UInt64 = min(64 * 1024, size)
+        do {
+            try handle.seek(toOffset: size - probeSize)
+        } catch {
+            return "ZIP probe: cannot seek (size=\(size))"
+        }
+        guard let tail = try? handle.read(upToCount: Int(probeSize)) else {
+            return "ZIP probe: cannot read (size=\(size))"
+        }
+        // EOCD signature: 0x06054b50 little-endian == PK\x05\x06
+        let eocdSignature = Data([0x50, 0x4b, 0x05, 0x06])
+        if tail.range(of: eocdSignature) != nil {
+            return "ZIP probe: EOCD found (size=\(size)) — file structurally valid but couldn't open"
+        }
+        return "ZIP probe: NO EOCD found (size=\(size)) — file likely truncated mid-write"
     }
 
     private static func sanitizedArchiveEntryURL(_ entryPath: String, destinationRoot: URL) -> URL? {
@@ -309,9 +353,10 @@ enum BoardArchiver {
 
     enum ImportError: LocalizedError {
         case unsupportedFileExtension
-        case corruptedFile
-        case ioFailure
+        case corruptedFile(failingEntryPath: String?)
+        case ioFailure(underlying: Error?)
 
+        /// Plain-language; surfaces in user-facing alerts.
         var errorDescription: String? {
             switch self {
             case .unsupportedFileExtension:
@@ -320,6 +365,18 @@ enum BoardArchiver {
                 return "This board file is incomplete or damaged. It may have been interrupted while saving."
             case .ioFailure:
                 return "The board file couldn't be read. Check that it's available and try again."
+            }
+        }
+
+        /// Developer detail for logs — not shown in the alert text.
+        var failureReason: String? {
+            switch self {
+            case .unsupportedFileExtension:
+                return nil
+            case .corruptedFile(let path):
+                return path.map { "Bad ZIP entry path: \($0)" }
+            case .ioFailure(let underlying):
+                return underlying.map { "Underlying error: \($0.localizedDescription)" }
             }
         }
     }

--- a/SuperCoolArtReferenceTool/App/BoardArchiver.swift
+++ b/SuperCoolArtReferenceTool/App/BoardArchiver.swift
@@ -241,7 +241,7 @@ enum BoardArchiver {
     private static func unzipItem(at sourceURL: URL, to destinationURL: URL) throws {
         guard let archive = Archive(url: sourceURL, accessMode: .read) else {
             let probe = probeZipTail(sourceURL)
-            Logger.archiver.error("Archive open failed for \(sourceURL.lastPathComponent, privacy: .public). \(probe, privacy: .public)")
+            Logger.archiver.error("Archive open failed for \(sourceURL.lastPathComponent, privacy: .private). \(probe, privacy: .public)")
             throw ImportError.ioFailure(underlying: nil)
         }
 

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 import os
 
-private let saveLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "Save")
-
 struct ContentView: View {
     @Environment(AppOpenHandler.self) private var openHandler
     @Environment(RecentBoardsManager.self) private var recentsManager
@@ -102,7 +100,7 @@ struct ContentView: View {
                 Button("Import") {
                     importerMode = .board
                     lastImporterMode = .board
-                    print("[UI] Import Board tapped")
+                    Logger.importer.notice("Import Board tapped")
                 }
                 .buttonStyle(.bordered)
             }
@@ -136,11 +134,11 @@ struct ContentView: View {
             allowsMultipleSelection: importerMode == .images
         ) { result in
             let currentMode = lastImporterMode
-            print("[Importer] Unified fileImporter fired (mode: \(String(describing: currentMode)))")
+            Logger.importer.info("fileImporter fired (mode: \(String(describing: currentMode), privacy: .public))")
             switch result {
             case .success(let urls):
                 if currentMode == .images {
-                    print("[Importer] Selected image URLs count = \(urls.count)")
+                    Logger.importer.info("Selected image URLs count = \(urls.count)")
                     urlsToInsert = urls
                 } else if currentMode == .board {
                     guard let url = urls.first else { return }
@@ -195,7 +193,8 @@ struct ContentView: View {
                 openHandler.importedElements = nil
             }
         }
-        .onChange(of: scenePhase) { _, newPhase in
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            Logger.scenePhase.info("phase: \(String(describing: oldPhase), privacy: .public) → \(String(describing: newPhase), privacy: .public)")
             // Autosave on `.inactive`. We can't use `.background` because force-quit from the
             // app switcher sends SIGKILL before `.background` fires — the lifecycle goes
             // `.active → .inactive → killed`, skipping `.background`. `.inactive` does fire on
@@ -210,7 +209,7 @@ struct ContentView: View {
     }
     
     private func openImageImporter() {
-        print("[UI] Add Item tapped")
+        Logger.importer.notice("Add Item tapped")
         importerMode = .images
         lastImporterMode = .images
     }
@@ -233,10 +232,10 @@ struct ContentView: View {
         do {
             _ = try BoardArchiver.export(elements: elements, to: url)
             let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            saveLog.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .public) in \(ms)ms")
+            Logger.save.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .public) in \(ms)ms (provider: \(fileProviderDescription(for: url), privacy: .public))")
             markCleanTrigger = UUID()
         } catch {
-            saveLog.error("Autosave failed: \(error.localizedDescription, privacy: .public)")
+            Logger.save.error("Autosave failed for \(url.lastPathComponent, privacy: .public) (provider: \(fileProviderDescription(for: url), privacy: .public)): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -138,7 +138,7 @@ struct ContentView: View {
             switch result {
             case .success(let urls):
                 if currentMode == .images {
-                    Logger.importer.info("Selected image URLs count = \(urls.count)")
+                    Logger.importer.info("Selected image URLs count = \(urls.count, privacy: .public)")
                     urlsToInsert = urls
                 } else if currentMode == .board {
                     guard let url = urls.first else { return }
@@ -232,10 +232,10 @@ struct ContentView: View {
         do {
             _ = try BoardArchiver.export(elements: elements, to: url)
             let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            Logger.save.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .private) in \(ms)ms (provider: \(fileProviderDescription(for: url), privacy: .public))")
+            Logger.save.logSaveSuccess(elements: elements.count, url: url, durationMs: ms)
             markCleanTrigger = UUID()
         } catch {
-            Logger.save.error("Autosave failed for \(url.lastPathComponent, privacy: .private) (provider: \(fileProviderDescription(for: url), privacy: .public)): \(error.localizedDescription, privacy: .private)")
+            Logger.save.logSaveFailure(url: url, error: error)
         }
     }
 

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -232,10 +232,10 @@ struct ContentView: View {
         do {
             _ = try BoardArchiver.export(elements: elements, to: url)
             let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            Logger.save.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .public) in \(ms)ms (provider: \(fileProviderDescription(for: url), privacy: .public))")
+            Logger.save.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .private) in \(ms)ms (provider: \(fileProviderDescription(for: url), privacy: .public))")
             markCleanTrigger = UUID()
         } catch {
-            Logger.save.error("Autosave failed for \(url.lastPathComponent, privacy: .public) (provider: \(fileProviderDescription(for: url), privacy: .public)): \(error.localizedDescription, privacy: .public)")
+            Logger.save.error("Autosave failed for \(url.lastPathComponent, privacy: .private) (provider: \(fileProviderDescription(for: url), privacy: .public)): \(error.localizedDescription, privacy: .private)")
         }
     }
 

--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
+import os
+
+private let saveLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "Save")
 
 struct ContentView: View {
     @Environment(AppOpenHandler.self) private var openHandler
@@ -230,10 +233,10 @@ struct ContentView: View {
         do {
             _ = try BoardArchiver.export(elements: elements, to: url)
             let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            print("[Save] Autosave wrote \(elements.count) elements to \(url.lastPathComponent) in \(ms)ms")
+            saveLog.info("Autosave wrote \(elements.count) elements to \(url.lastPathComponent, privacy: .public) in \(ms)ms")
             markCleanTrigger = UUID()
         } catch {
-            print("[Save] Autosave failed: \(error.localizedDescription)")
+            saveLog.error("Autosave failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/SuperCoolArtReferenceTool/App/Loggers.swift
+++ b/SuperCoolArtReferenceTool/App/Loggers.swift
@@ -26,9 +26,8 @@ extension OSSignposter {
     static let archiver = OSSignposter(subsystem: subsystem, category: "Archiver")
 }
 
-/// Identifies which file provider backs a given URL — iCloud Drive, on-device storage,
-/// or a third-party Files extension (Working Copy, Dropbox, etc.). Useful in diagnostic
-/// logs so we can distinguish behavior across providers without correlating raw paths.
+/// Identifies which broad storage class backs a given URL without exposing
+/// provider-specific identifiers or raw path components in logs.
 func fileProviderDescription(for url: URL) -> String {
     let path = url.path
 
@@ -36,19 +35,11 @@ func fileProviderDescription(for url: URL) -> String {
         return "iCloud Drive"
     }
 
-    if let range = path.range(of: "/CloudStorage/") {
-        let tail = path[range.upperBound...]
-        if let slash = tail.firstIndex(of: "/") {
-            return "FileProvider:\(tail[..<slash])"
-        }
+    if path.contains("/CloudStorage/") {
         return "FileProvider"
     }
 
-    if let range = path.range(of: "/Mobile Documents/iCloud~") {
-        let tail = path[range.upperBound...]
-        if let slash = tail.firstIndex(of: "/") {
-            return "iCloudContainer:\(tail[..<slash])"
-        }
+    if path.contains("/Mobile Documents/iCloud~") {
         return "iCloudContainer"
     }
 

--- a/SuperCoolArtReferenceTool/App/Loggers.swift
+++ b/SuperCoolArtReferenceTool/App/Loggers.swift
@@ -1,0 +1,64 @@
+//
+//  Loggers.swift
+//  SuperCoolArtReferenceTool
+//
+//  Created by andy lin on 4/28/26.
+//
+
+import Foundation
+import os
+
+// Tracks whatever bundle id the current build was signed with so per-dev signing
+// (no shared developer certificate) doesn't break `log stream --predicate 'subsystem == ...'`.
+// Falls back to the canonical id only if Info.plist somehow lacks one.
+private let subsystem = Bundle.main.bundleIdentifier ?? "AxI.SuperCoolArtReferenceTool1"
+
+extension Logger {
+    static let app = Logger(subsystem: subsystem, category: "App")
+    static let save = Logger(subsystem: subsystem, category: "Save")
+    static let recents = Logger(subsystem: subsystem, category: "RecentBoards")
+    static let archiver = Logger(subsystem: subsystem, category: "Archiver")
+    static let importer = Logger(subsystem: subsystem, category: "Importer")
+    static let scenePhase = Logger(subsystem: subsystem, category: "ScenePhase")
+}
+
+extension OSSignposter {
+    static let archiver = OSSignposter(subsystem: subsystem, category: "Archiver")
+}
+
+/// Identifies which file provider backs a given URL — iCloud Drive, on-device storage,
+/// or a third-party Files extension (Working Copy, Dropbox, etc.). Useful in diagnostic
+/// logs so we can distinguish behavior across providers without correlating raw paths.
+func fileProviderDescription(for url: URL) -> String {
+    let path = url.path
+
+    if path.contains("com~apple~CloudDocs") {
+        return "iCloud Drive"
+    }
+
+    if let range = path.range(of: "/CloudStorage/") {
+        let tail = path[range.upperBound...]
+        if let slash = tail.firstIndex(of: "/") {
+            return "FileProvider:\(tail[..<slash])"
+        }
+        return "FileProvider"
+    }
+
+    if let range = path.range(of: "/Mobile Documents/iCloud~") {
+        let tail = path[range.upperBound...]
+        if let slash = tail.firstIndex(of: "/") {
+            return "iCloudContainer:\(tail[..<slash])"
+        }
+        return "iCloudContainer"
+    }
+
+    if path.contains("/Containers/Data/Application/") {
+        return "AppContainer"
+    }
+
+    if path.hasPrefix("/Users/") {
+        return "Simulator"
+    }
+
+    return "Other"
+}

--- a/SuperCoolArtReferenceTool/App/Loggers.swift
+++ b/SuperCoolArtReferenceTool/App/Loggers.swift
@@ -14,21 +14,97 @@ import os
 private let subsystem = Bundle.main.bundleIdentifier ?? "AxI.SuperCoolArtReferenceTool1"
 
 extension Logger {
-    static let app = Logger(subsystem: subsystem, category: "App")
-    static let save = Logger(subsystem: subsystem, category: "Save")
-    static let recents = Logger(subsystem: subsystem, category: "RecentBoards")
-    static let archiver = Logger(subsystem: subsystem, category: "Archiver")
-    static let importer = Logger(subsystem: subsystem, category: "Importer")
-    static let scenePhase = Logger(subsystem: subsystem, category: "ScenePhase")
+    nonisolated static let app = Logger(subsystem: subsystem, category: "App")
+    nonisolated static let save = Logger(subsystem: subsystem, category: "Save")
+    nonisolated static let recents = Logger(subsystem: subsystem, category: "RecentBoards")
+    nonisolated static let archiver = Logger(subsystem: subsystem, category: "Archiver")
+    nonisolated static let importer = Logger(subsystem: subsystem, category: "Importer")
+    nonisolated static let scenePhase = Logger(subsystem: subsystem, category: "ScenePhase")
 }
 
 extension OSSignposter {
-    static let archiver = OSSignposter(subsystem: subsystem, category: "Archiver")
+    nonisolated static let archiver = OSSignposter(subsystem: subsystem, category: "Archiver")
 }
 
-/// Identifies which broad storage class backs a given URL without exposing
-/// provider-specific identifiers or raw path components in logs.
-func fileProviderDescription(for url: URL) -> String {
+// MARK: - Privacy-aware log helpers
+//
+// These helpers wrap the common log shapes so the privacy decision (DEBUG → .public for
+// `log stream` debugging; release → .private(mask: .hash) so lines stay correlatable
+// without leaking) lives in one place. Adding a new persistence-related log? Add a
+// helper here rather than calling `Logger.<category>.info(...)` directly, so the privacy
+// rule stays uniform across the codebase. `OSLogPrivacy` can't be extended with custom
+// values — the OSLog macro requires built-in static members at compile time — so we route
+// through these wrappers instead.
+
+extension Logger {
+    /// Autosave success. Filename privacy varies by build; element count, duration, and
+    /// provider class are always public (non-sensitive).
+    nonisolated func logSaveSuccess(elements: Int, url: URL, durationMs: Int) {
+        let provider = fileProviderDescription(for: url)
+        #if DEBUG
+        self.info("Autosave wrote \(elements, privacy: .public) elements to \(url.lastPathComponent, privacy: .public) in \(durationMs, privacy: .public)ms (provider: \(provider, privacy: .public))")
+        #else
+        self.info("Autosave wrote \(elements, privacy: .public) elements to \(url.lastPathComponent, privacy: .private(mask: .hash)) in \(durationMs, privacy: .public)ms (provider: \(provider, privacy: .public))")
+        #endif
+    }
+
+    /// Save failure. Surfaces `LocalizedError.failureReason` so `ArchiverError`'s
+    /// associated values (bad ZIP entry path, underlying error) reach logs.
+    nonisolated func logSaveFailure(url: URL, error: Error) {
+        let provider = fileProviderDescription(for: url)
+        let suffix = failureReasonSuffix(for: error)
+        #if DEBUG
+        self.error("Autosave failed for \(url.lastPathComponent, privacy: .public) (provider: \(provider, privacy: .public)): \(error.localizedDescription, privacy: .public)\(suffix, privacy: .public)")
+        #else
+        self.error("Autosave failed for \(url.lastPathComponent, privacy: .private(mask: .hash)) (provider: \(provider, privacy: .public)): \(error.localizedDescription, privacy: .private(mask: .hash))\(suffix, privacy: .private(mask: .hash))")
+        #endif
+    }
+
+    /// URL receipt — for app-open / fileImporter entry points where we want to know the
+    /// URL arrived at all (separate from any subsequent failure log).
+    nonisolated func logURLReceipt(url: URL, kind: String) {
+        let provider = fileProviderDescription(for: url)
+        #if DEBUG
+        self.notice("\(kind, privacy: .public) received: \(url.lastPathComponent, privacy: .public) (provider: \(provider, privacy: .public))")
+        #else
+        self.notice("\(kind, privacy: .public) received: \(url.lastPathComponent, privacy: .private(mask: .hash)) (provider: \(provider, privacy: .public))")
+        #endif
+    }
+
+    /// Generic error log without a URL — surfaces `LocalizedError.failureReason`.
+    nonisolated func logFailure(_ context: String, error: Error) {
+        let suffix = failureReasonSuffix(for: error)
+        #if DEBUG
+        self.error("\(context, privacy: .public): \(error.localizedDescription, privacy: .public)\(suffix, privacy: .public)")
+        #else
+        self.error("\(context, privacy: .public): \(error.localizedDescription, privacy: .private(mask: .hash))\(suffix, privacy: .private(mask: .hash))")
+        #endif
+    }
+
+    /// Archive-open failure — pairs a sensitive filename with the ZIP-tail probe result
+    /// (always public, since the probe output is bounded developer-controlled text).
+    nonisolated func logArchiveOpenFailed(url: URL, probe: String) {
+        #if DEBUG
+        self.error("Archive open failed for \(url.lastPathComponent, privacy: .public). \(probe, privacy: .public)")
+        #else
+        self.error("Archive open failed for \(url.lastPathComponent, privacy: .private(mask: .hash)). \(probe, privacy: .public)")
+        #endif
+    }
+}
+
+/// Extracts `LocalizedError.failureReason` as a `" — \(reason)"` suffix to fold into
+/// existing Logger format strings. Returns empty when the error doesn't conform to
+/// `LocalizedError` or has no reason — pairs with `BoardArchiver.ArchiverError`
+/// whose associated values surface bad ZIP entry paths and underlying errors.
+nonisolated func failureReasonSuffix(for error: Error) -> String {
+    (error as? LocalizedError)?.failureReason.map { " — \($0)" } ?? ""
+}
+
+/// Identifies which broad storage class backs a given URL. Release builds return
+/// only the broad class; DEBUG builds extend `FileProvider` / `iCloudContainer`
+/// with the provider's bundle suffix (`FileProvider:WorkingCopy-XYZ`) so we can
+/// attribute provider-specific bugs without leaking that data into release logs.
+nonisolated func fileProviderDescription(for url: URL) -> String {
     let path = url.path
 
     if path.contains("com~apple~CloudDocs") {
@@ -36,10 +112,26 @@ func fileProviderDescription(for url: URL) -> String {
     }
 
     if path.contains("/CloudStorage/") {
+        #if DEBUG
+        if let range = path.range(of: "/CloudStorage/") {
+            let tail = path[range.upperBound...]
+            if let slash = tail.firstIndex(of: "/") {
+                return "FileProvider:\(tail[..<slash])"
+            }
+        }
+        #endif
         return "FileProvider"
     }
 
     if path.contains("/Mobile Documents/iCloud~") {
+        #if DEBUG
+        if let range = path.range(of: "/Mobile Documents/iCloud~") {
+            let tail = path[range.upperBound...]
+            if let slash = tail.firstIndex(of: "/") {
+                return "iCloudContainer:\(tail[..<slash])"
+            }
+        }
+        #endif
         return "iCloudContainer"
     }
 

--- a/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
+++ b/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
@@ -16,7 +16,7 @@ struct SuperCoolArtReferenceToolApp: App {
             RootView()
                 .environment(openHandler)
                 .onOpenURL { url in
-                    Logger.app.notice("onOpenURL received: \(url.lastPathComponent, privacy: .private) (provider: \(fileProviderDescription(for: url), privacy: .public))")
+                    Logger.app.logURLReceipt(url: url, kind: "onOpenURL")
                     Task {
                         guard url.pathExtension.lowercased() == "refboard" else { return }
                         do {
@@ -25,7 +25,7 @@ struct SuperCoolArtReferenceToolApp: App {
                                 openHandler.importedElements = elements
                             }
                         } catch {
-                            Logger.app.error("Failed to import .refboard: \(error.localizedDescription, privacy: .private)")
+                            Logger.app.logFailure("Failed to import .refboard", error: error)
                         }
                     }
                 }

--- a/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
+++ b/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
@@ -16,7 +16,7 @@ struct SuperCoolArtReferenceToolApp: App {
             RootView()
                 .environment(openHandler)
                 .onOpenURL { url in
-                    Logger.app.notice("onOpenURL received: \(url.lastPathComponent, privacy: .public) (provider: \(fileProviderDescription(for: url), privacy: .public))")
+                    Logger.app.notice("onOpenURL received: \(url.lastPathComponent, privacy: .private) (provider: \(fileProviderDescription(for: url), privacy: .public))")
                     Task {
                         guard url.pathExtension.lowercased() == "refboard" else { return }
                         do {
@@ -25,7 +25,7 @@ struct SuperCoolArtReferenceToolApp: App {
                                 openHandler.importedElements = elements
                             }
                         } catch {
-                            Logger.app.error("Failed to import .refboard: \(error.localizedDescription, privacy: .public)")
+                            Logger.app.error("Failed to import .refboard: \(error.localizedDescription, privacy: .private)")
                         }
                     }
                 }

--- a/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
+++ b/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+import os
+
+private let appLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "App")
 
 @main
 struct SuperCoolArtReferenceToolApp: App {
@@ -23,7 +26,7 @@ struct SuperCoolArtReferenceToolApp: App {
                                 openHandler.importedElements = elements
                             }
                         } catch {
-                            print("Failed to import .refboard: ", error)
+                            appLog.error("Failed to import .refboard: \(error.localizedDescription, privacy: .public)")
                         }
                     }
                 }

--- a/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
+++ b/SuperCoolArtReferenceTool/App/SuperCoolArtReferenceToolApp.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import os
 
-private let appLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "App")
-
 @main
 struct SuperCoolArtReferenceToolApp: App {
     @State private var openHandler = AppOpenHandler()
@@ -18,6 +16,7 @@ struct SuperCoolArtReferenceToolApp: App {
             RootView()
                 .environment(openHandler)
                 .onOpenURL { url in
+                    Logger.app.notice("onOpenURL received: \(url.lastPathComponent, privacy: .public) (provider: \(fileProviderDescription(for: url), privacy: .public))")
                     Task {
                         guard url.pathExtension.lowercased() == "refboard" else { return }
                         do {
@@ -26,7 +25,7 @@ struct SuperCoolArtReferenceToolApp: App {
                                 openHandler.importedElements = elements
                             }
                         } catch {
-                            appLog.error("Failed to import .refboard: \(error.localizedDescription, privacy: .public)")
+                            Logger.app.error("Failed to import .refboard: \(error.localizedDescription, privacy: .public)")
                         }
                     }
                 }

--- a/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
+++ b/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
@@ -126,7 +126,7 @@ final class RecentBoardsManager {
             entries.sort { $0.lastOpened > $1.lastOpened }
             return entries
         } catch {
-            Logger.recents.error("Failed to load: \(error.localizedDescription, privacy: .public)")
+            Logger.recents.error("Failed to load: \(error.localizedDescription, privacy: .private)")
             return []
         }
     }
@@ -138,7 +138,7 @@ final class RecentBoardsManager {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
         } catch {
-            Logger.recents.error("Failed to save: \(error.localizedDescription, privacy: .public)")
+            Logger.recents.error("Failed to save: \(error.localizedDescription, privacy: .private)")
         }
     }
 }

--- a/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
+++ b/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let recentsLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "RecentBoards")
 
 struct RecentBoardEntry: Codable, Identifiable {
     var id: String { filePath }
@@ -125,7 +128,7 @@ final class RecentBoardsManager {
             entries.sort { $0.lastOpened > $1.lastOpened }
             return entries
         } catch {
-            print("[RecentBoards] Failed to load: \(error.localizedDescription)")
+            recentsLog.error("Failed to load: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -137,7 +140,7 @@ final class RecentBoardsManager {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
         } catch {
-            print("[RecentBoards] Failed to save: \(error.localizedDescription)")
+            recentsLog.error("Failed to save: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
+++ b/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
@@ -1,8 +1,6 @@
 import Foundation
 import os
 
-private let recentsLog = Logger(subsystem: "AxI.SuperCoolArtReferenceTool1", category: "RecentBoards")
-
 struct RecentBoardEntry: Codable, Identifiable {
     var id: String { filePath }
     let name: String
@@ -128,7 +126,7 @@ final class RecentBoardsManager {
             entries.sort { $0.lastOpened > $1.lastOpened }
             return entries
         } catch {
-            recentsLog.error("Failed to load: \(error.localizedDescription, privacy: .public)")
+            Logger.recents.error("Failed to load: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
@@ -140,7 +138,7 @@ final class RecentBoardsManager {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
         } catch {
-            recentsLog.error("Failed to save: \(error.localizedDescription, privacy: .public)")
+            Logger.recents.error("Failed to save: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
+++ b/SuperCoolArtReferenceTool/Features/FilePicker/RecentBoardsManager.swift
@@ -126,7 +126,7 @@ final class RecentBoardsManager {
             entries.sort { $0.lastOpened > $1.lastOpened }
             return entries
         } catch {
-            Logger.recents.error("Failed to load: \(error.localizedDescription, privacy: .private)")
+            Logger.recents.logFailure("Failed to load", error: error)
             return []
         }
     }
@@ -138,7 +138,7 @@ final class RecentBoardsManager {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
         } catch {
-            Logger.recents.error("Failed to save: \(error.localizedDescription, privacy: .private)")
+            Logger.recents.logFailure("Failed to save", error: error)
         }
     }
 }

--- a/architecture-backend.md
+++ b/architecture-backend.md
@@ -97,6 +97,66 @@ Both paths converge on `BoardArchiver.importElements(...)`, which produces `[CMC
 
 ---
 
+## Persistence Diagnostics
+
+Decision Status: **Implemented**
+
+**Files:**
+- `SuperCoolArtReferenceTool/App/Loggers.swift`
+- `SuperCoolArtReferenceTool/App/BoardArchiver.swift`
+
+Diagnostics for the import/export/save surface, designed so production logs are useful for narrowing down user-reported failures without leaking sensitive filenames or error text.
+
+### Logger setup
+
+`Loggers.swift` centralizes Logger / OSSignposter declarations. Subsystem auto-derives from `Bundle.main.bundleIdentifier` so per-dev signing (no shared developer certificate, each dev's Apple ID team produces a different bundle id) doesn't break log filtering. Six categories: `App` (`.onOpenURL`), `Save` (autosave), `RecentBoards` (bookmark I/O), `Archiver` (ZIP open failures + probe), `Importer` (file picker results), `ScenePhase` (lifecycle). Filter via `log stream --predicate 'subsystem == "<bundle-id>" && category == "Save"'` or Console.app's category filter.
+
+### Log privacy policy
+
+`OSLogPrivacy` cannot be extended with custom static values — the OSLog macro performs a compile-time check that only accepts the framework's built-in members. Privacy is therefore baked into wrapper methods on `Logger` (`logSaveSuccess`, `logSaveFailure`, `logURLReceipt`, `logFailure`, `logArchiveOpenFailed`). **Add a new persistence-related log via a wrapper rather than calling `Logger.<category>.info(...)` directly** so the privacy rule stays uniform.
+
+| Field | DEBUG | Release |
+|---|---|---|
+| Filename (`url.lastPathComponent`) | `.public` | `.private(mask: .hash)` |
+| Error description / failure reason | `.public` | `.private(mask: .hash)` |
+| Provider class, element count, duration, probe result, signpost metadata | `.public` | `.public` |
+
+The hashed-mask in release lets log lines correlate ("save failed for X" → "save retried for X") without leaking the raw filename.
+
+### File-provider attribution
+
+`fileProviderDescription(for:)` returns the broad storage class — `iCloud Drive`, `FileProvider`, `iCloudContainer`, `AppContainer`, `Simulator`, `Other`. DEBUG builds additionally extend `FileProvider` / `iCloudContainer` with the provider's bundle suffix (`FileProvider:WorkingCopy-XYZ`) so we can attribute provider-specific bugs locally; release builds drop the suffix.
+
+The third-party-attribution split exists because a corruption report on `.refboard` files saved through Working Copy (a Files-extension app) needed provider-level resolution to diagnose, but the raw provider name shouldn't ship to release logs.
+
+### `ArchiverError` (formerly `ImportError`)
+
+`BoardArchiver.ArchiverError: LocalizedError` covers both import and export paths — the boundary type name reflects the archiver boundary, not one direction across it. Cases:
+
+- `unsupportedFileExtension` — wrong file extension (import-only path).
+- `corruptedFile(failingEntryPath: String?)` — package layout invalid, manifest missing, or `unzipItem` rejected a ZIP entry path. Associated value carries the bad path when known.
+- `ioFailure(underlying: Error?)` — `Archive(url:accessMode:)` returned nil for read or write. Associated value reserved for the underlying error if a future ZIPFoundation surface exposes one.
+
+`errorDescription` is plain-language for user alerts; the developer-facing `failureReason` (bad ZIP entry path / underlying error) is folded into log lines via `failureReasonSuffix(for:)` inside the `Logger.log*Failure` wrappers, so the associated-value detail reaches `log stream` without surfacing in the user's alert text.
+
+Splitting into separate `ImportError` / `ExportError` types is deferred until a third call site appears or import/export diverge in error data (e.g. export needs `diskFull(bytesRequired:)`). Today there's one call site each and type-level discrimination buys nothing the compiler isn't already giving.
+
+### OSSignposter intervals
+
+`OSSignposter.archiver` emits begin/end intervals around `BoardArchiver.export` and `.importElements`. Metadata attached to each interval (`provider: <class>`, plus `elements: <count>` on export) is `.public` so it shows in Instruments under `subsystem == "<bundle-id>"` + `category == "Archiver"`. This is the tool for answering "is provider X slow or wrong?" — measure per-provider duration across real saves.
+
+### ZIP-tail probe
+
+When `Archive(url:accessMode: .read)` returns nil inside `unzipItem`, `probeZipTail` reads the trailing 64KB of the file and reports whether the ZIP End-of-Central-Directory signature (`PK\x05\x06`) is present:
+
+- `ZIP probe: NO EOCD found (size=N) — file likely truncated mid-write` — points at killed-during-save (the suspected Working Copy bug shape).
+- `ZIP probe: EOCD found (size=N) — file structurally valid but couldn't open` — points elsewhere (header corruption, permission, ZIPFoundation issue).
+- Diagnostic strings prefixed `ZIP probe:` for intermediate stat/open/seek/read failures.
+
+Logged via `Logger.archiver.logArchiveOpenFailed(url:probe:)`.
+
+---
+
 ## Spatial Query Helpers
 
 Decision Status: **Implemented**


### PR DESCRIPTION
## Summary
- Replace persistence-adjacent `print` calls with categorized `os.Logger` and add `LocalizedError` on `BoardArchiver.ImportError` so alerts show plain-language text instead of "(BoardArchiver.ImportError error 1)". Subsystem auto-derives from `Bundle.main.bundleIdentifier` so per-dev signing (no shared developer certificate) doesn't break `log stream` filters.
- Centralize Logger declarations + `OSSignposter` in a new `Loggers.swift` (categories `App`/`Save`/`RecentBoards`/`Archiver`/`Importer`/`ScenePhase`). Add signpost intervals around `BoardArchiver.export` and `.importElements` for Instruments-friendly per-save timing. Tag every save log line and signpost with the URL's file-provider (`iCloud Drive`, `FileProvider:WorkingCopy`, `AppContainer`, etc.) so slow/failed saves can be attributed to their backing storage.
- Enrich `ImportError` with associated values (`corruptedFile(failingEntryPath:)`, `ioFailure(underlying:)`) and a developer-facing `failureReason`. Add a ZIP central-directory probe on `Archive(.read)` failure that reads the trailing 64KB and reports whether the EOCD signature exists — distinguishes "killed mid-write / truncated" from "structurally valid but unreadable." Log scenePhase transitions and `onOpenURL` URL receipt so reports can distinguish "URL never arrived" from "save failed."

## Test plan
- [ ] Build for iPad simulator passes
- [ ] Run on device, open a `.refboard`, confirm `log stream --predicate 'subsystem == "<bundle-id>"'` shows entries under `Save` / `Importer` / `App` / `Archiver` / `ScenePhase` categories
- [ ] Verify the import-failure alert shows the full sentence ("This board file is incomplete or damaged…") instead of "error 1"
- [ ] If a corrupted `.refboard` is available, confirm the archiver log line reports `ZIP probe: NO EOCD found` for truncated files (and `EOCD found` for archives that are structurally valid but otherwise unreadable)
- [ ] Profile a save in Instruments — the `export`/`import` signpost intervals should appear with file-provider metadata in the timeline

## Out of scope
The atomic-write fix that originally prompted this branch was reverted ([discussion in conversation context]) because it regressed autosave perf on Files-provider locations. This PR is the diagnostics groundwork so the next attempt at fixing the corruption bug can be measured properly. The reported corruption is suspected to be specific to third-party Files providers (Working Copy) but isn't yet locally reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)