### PR TITLE
Move DEVELOPMENT_TEAM into per-developer xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ playground.xcworkspace
 # User-specific merges/patches
 *.orig
 
+# Per-developer signing config (each dev creates their own from Local.xcconfig.example)
+Config/Local.xcconfig
+
 # Agent skills (dev-specific)
 .agents/
 .claude/skills/

--- a/Config/Local.xcconfig.example
+++ b/Config/Local.xcconfig.example
@@ -1,0 +1,7 @@
+// Copy this file to Config/Local.xcconfig and fill in your personal Apple
+// Developer team ID. Local.xcconfig is gitignored, so your team ID never
+// gets committed and won't conflict with other developers.
+//
+// Find your team ID in Xcode: Settings → Accounts → select your account → "Team ID".
+
+DEVELOPMENT_TEAM = YOUR_TEAM_ID_HERE

--- a/Config/Shared.xcconfig
+++ b/Config/Shared.xcconfig
@@ -1,0 +1,5 @@
+// Shared build settings — committed.
+// Local overrides live in Config/Local.xcconfig (gitignored).
+// When the team gets a shared Apple Developer cert, set DEVELOPMENT_TEAM here.
+
+#include? "Local.xcconfig"

--- a/SuperCoolArtReferenceTool.xcodeproj/project.pbxproj
+++ b/SuperCoolArtReferenceTool.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		42D648282F758E8D00E2B842 /* architecture-frontend.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "architecture-frontend.md"; sourceTree = "<group>"; };
 		42D6482A2F758EC400E2B842 /* architecture-backend.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "architecture-backend.md"; sourceTree = "<group>"; };
 		6CC1DB872F735E1400188778 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		42CF160100000000A0000001 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Config/Shared.xcconfig; sourceTree = "<group>"; };
+		42CF160100000000A0000002 /* Local.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text; name = Local.xcconfig.example; path = Config/Local.xcconfig.example; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -41,6 +43,7 @@
 		425F7A162F43AA8100B7E65B = {
 			isa = PBXGroup;
 			children = (
+				42CF160100000000A0000003 /* Config */,
 				425F7A212F43AA8100B7E65B /* SuperCoolArtReferenceTool */,
 				425F7A202F43AA8100B7E65B /* Products */,
 				6CC1DB872F735E1400188778 /* .gitignore */,
@@ -48,6 +51,15 @@
 				42D6482A2F758EC400E2B842 /* architecture-backend.md */,
 				428969D02F7C433300C0436A /* context.md */,
 			);
+			sourceTree = "<group>";
+		};
+		42CF160100000000A0000003 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				42CF160100000000A0000001 /* Shared.xcconfig */,
+				42CF160100000000A0000002 /* Local.xcconfig.example */,
+			);
+			name = Config;
 			sourceTree = "<group>";
 		};
 		425F7A202F43AA8100B7E65B /* Products */ = {
@@ -263,12 +275,12 @@
 		};
 		425F7A2B2F43AA8300B7E65B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42CF160100000000A0000001 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JX98H68QDZ;
 				ENABLE_PREVIEWS = YES;
 				EXCLUDED_SOURCE_FILE_NAMES = "*.md";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -296,12 +308,12 @@
 		};
 		425F7A2C2F43AA8300B7E65B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42CF160100000000A0000001 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JX98H68QDZ;
 				ENABLE_PREVIEWS = YES;
 				EXCLUDED_SOURCE_FILE_NAMES = "*.md";
 				GENERATE_INFOPLIST_FILE = YES;


### PR DESCRIPTION
## Summary
- Replace hardcoded `DEVELOPMENT_TEAM` in `project.pbxproj` with a `Config/Shared.xcconfig` that optionally includes a per-developer `Config/Local.xcconfig`
- `Config/Local.xcconfig` is gitignored — each dev keeps their own team ID locally, so signing never drifts into git again
- Future-proof: when a shared Apple Developer cert lands, set `DEVELOPMENT_TEAM` in `Shared.xcconfig` once and everyone picks it up automatically; `Local.xcconfig` stays available as a personal override

## Setup for other developers (one-time, after pulling)
1. Discard any local pbxproj signing edits: `git checkout -- SuperCoolArtReferenceTool.xcodeproj/project.pbxproj`
2. Copy the template: `cp Config/Local.xcconfig.example Config/Local.xcconfig`
3. Edit `Config/Local.xcconfig` and set `DEVELOPMENT_TEAM = <your team ID>` (Xcode → Settings → Accounts → Team ID)
4. Build — Xcode picks up the value automatically

## Test plan
- [x] `xcodebuild build` succeeds for iOS Simulator
- [ ] Verify a fresh clone + Local.xcconfig setup builds cleanly
- [ ] Confirm `git status` stays clean after a build (no pbxproj drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)