### PR TITLE
Minimap, home button, and landing snap

### DIFF
--- a/SuperCoolArtReferenceTool/App/ContentView.swift
+++ b/SuperCoolArtReferenceTool/App/ContentView.swift
@@ -43,10 +43,11 @@ struct ContentView: View {
     @State private var snapshotToken: UUID?
     @State private var elementsToLoad: [CMCanvasElement]?
 
-    // Undo/redo
+    // Undo/redo/home
     @State private var commandHistory = CanvasCommandHistory()
     @State private var undoTrigger: UUID?
     @State private var redoTrigger: UUID?
+    @State private var homeTrigger: UUID?
     @State private var markCleanTrigger: UUID?
 
     @State private var importerPresented = false
@@ -105,6 +106,7 @@ struct ContentView: View {
                 commandHistory: commandHistory,
                 undoTrigger: $undoTrigger,
                 redoTrigger: $redoTrigger,
+                homeTrigger: $homeTrigger,
                 markCleanTrigger: $markCleanTrigger,
                 onInsertURLs: { _ in },
                 onSnapshot: { elements, wasDirty in
@@ -125,6 +127,7 @@ struct ContentView: View {
                     onBack: handleBack,
                     onUndo: { undoTrigger = UUID() },
                     onRedo: { redoTrigger = UUID() },
+                    onHome: { homeTrigger = UUID() },
                     onAddItem: openImageImporter,
                     onSettings: { showingSettings = true }
                 )

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -533,6 +533,9 @@ struct BoardCanvasView: View {
                     applyElements(els)
                     commandHistory.clear()
                     selection.clearSelection()
+                    if !els.isEmpty {
+                        snapToContentCenter()
+                    }
                     // Clear the binding after applying
                     DispatchQueue.main.async {
                         elementsToLoad = nil
@@ -2148,6 +2151,19 @@ struct BoardCanvasView: View {
         var rects = placedImages.map(\.worldRect)
         rects.append(contentsOf: placedTexts.map(\.worldRect))
         return rects
+    }
+
+    /// Instantly position the viewport so the center of all canvas content is
+    /// centered on screen. Used on board load — no animation, no flash.
+    private func snapToContentCenter() {
+        guard canvasSize != .zero, scale > 0 else { return }
+        let allRects = allElementRects()
+        guard let bounds = union(of: allRects) else { return }
+        offset = CGSize(
+            width: canvasSize.width / 2 - bounds.midX * scale,
+            height: canvasSize.height / 2 - bounds.midY * scale
+        )
+        scheduleRefreshVisibleElements()
     }
 
     /// Animate the viewport so the center of all canvas content is centered

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -534,7 +534,7 @@ struct BoardCanvasView: View {
                     commandHistory.clear()
                     selection.clearSelection()
                     if !els.isEmpty {
-                        snapToContentCenter()
+                        jumpToContentCenter(animated: false)
                     }
                     // Clear the binding after applying
                     DispatchQueue.main.async {
@@ -2153,22 +2153,10 @@ struct BoardCanvasView: View {
         return rects
     }
 
-    /// Instantly position the viewport so the center of all canvas content is
-    /// centered on screen. Used on board load — no animation, no flash.
-    private func snapToContentCenter() {
-        guard canvasSize != .zero, scale > 0 else { return }
-        let allRects = allElementRects()
-        guard let bounds = union(of: allRects) else { return }
-        offset = CGSize(
-            width: canvasSize.width / 2 - bounds.midX * scale,
-            height: canvasSize.height / 2 - bounds.midY * scale
-        )
-        scheduleRefreshVisibleElements()
-    }
-
-    /// Animate the viewport so the center of all canvas content is centered
-    /// on screen, preserving the current zoom level.
-    private func jumpToContentCenter() {
+    /// Center the viewport on all canvas content. Pass `animated: false` for
+    /// instant repositioning (e.g. on board load); `true` for the home button
+    /// eased pan.
+    private func jumpToContentCenter(animated: Bool = true) {
         guard canvasSize != .zero, scale > 0 else { return }
         let allRects = allElementRects()
         let centerX: CGFloat
@@ -2180,12 +2168,18 @@ struct BoardCanvasView: View {
             centerX = 0
             centerY = 0
         }
-        withAnimation(.easeInOut(duration: 0.4)) {
-            offset = CGSize(
-                width: canvasSize.width / 2 - centerX * scale,
-                height: canvasSize.height / 2 - centerY * scale
-            )
-        } completion: {
+        let target = CGSize(
+            width: canvasSize.width / 2 - centerX * scale,
+            height: canvasSize.height / 2 - centerY * scale
+        )
+        if animated {
+            withAnimation(.easeInOut(duration: 0.4)) {
+                offset = target
+            } completion: {
+                scheduleRefreshVisibleElements()
+            }
+        } else {
+            offset = target
             scheduleRefreshVisibleElements()
         }
     }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -472,11 +472,10 @@ struct BoardCanvasView: View {
                 if camera.offset == .zero {
                     camera.offset = CGSize(width: geo.size.width / 2, height: geo.size.height / 2)
                 }
-                // If elements were already applied before canvasSize was available
-                // (ContentView.onAppear fired before this onAppear), snap to content
-                // center now that canvasSize is known. jumpToContentCenter also calls
-                // scheduleRefreshVisibleElements, so skip the standalone call below.
-                if !placedImages.isEmpty || !placedTexts.isEmpty {
+                // If elements were already applied AND no pending load is in flight
+                // (elementsToLoad non-nil means the deferred DispatchQueue handler
+                // will snap after it fires — gating here avoids a redundant double call).
+                if elementsToLoad == nil && (!placedImages.isEmpty || !placedTexts.isEmpty) {
                     jumpToContentCenter(animated: false)
                 } else {
                     scheduleRefreshVisibleElements()

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import UniformTypeIdentifiers
-import UIKit
 import ImageIO
 import simd
 
@@ -276,6 +275,7 @@ struct BoardCanvasView: View {
                                 await refreshVisibleElements()
                             }
                         }
+                        .accessibilityAddTraits(.isButton)
                         .position(x: (liveRect.midX * camera.scale) + camera.offset.width + liveDX,
                                   y: (liveRect.midY * camera.scale) + camera.offset.height + liveDY)
                         .shadow(radius: isInteracting ? 0 : 1)
@@ -332,6 +332,7 @@ struct BoardCanvasView: View {
                             await behavior.tappedItem(id: id, store: store, selection: sel)
                         }
                     }
+                    .accessibilityAddTraits(.isButton)
                     .zIndex(Double(placed.zIndex))
                 }
 
@@ -497,7 +498,7 @@ struct BoardCanvasView: View {
                     if isFirstInsert {
                         commandHistory.clear()
                     }
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         externalInsertURLs = nil
                     }
                 }
@@ -593,17 +594,17 @@ struct BoardCanvasView: View {
             .onChange(of: undoTrigger) { _, newValue in
                 guard newValue != nil else { return }
                 performUndo()
-                DispatchQueue.main.async { undoTrigger = nil }
+                Task { @MainActor in undoTrigger = nil }
             }
             .onChange(of: redoTrigger) { _, newValue in
                 guard newValue != nil else { return }
                 performRedo()
-                DispatchQueue.main.async { redoTrigger = nil }
+                Task { @MainActor in redoTrigger = nil }
             }
             .onChange(of: homeTrigger) { _, newValue in
                 guard newValue != nil else { return }
                 jumpToContentCenter()
-                DispatchQueue.main.async { homeTrigger = nil }
+                Task { @MainActor in homeTrigger = nil }
             }
             .contentShape(Rectangle())
             // Drag: routed through active tool behavior
@@ -753,7 +754,7 @@ struct BoardCanvasView: View {
     private func endInteraction() {
         interactionEndTask?.cancel()
         interactionEndTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 150_000_000)
+            try? await Task.sleep(for: .milliseconds(150))
             isInteracting = false
         }
     }
@@ -1861,8 +1862,7 @@ struct BoardCanvasView: View {
     private func scheduleRefreshVisibleElements() {
         refreshTask?.cancel()
         refreshTask = Task { @MainActor in
-            let delay: UInt64 = isInteracting ? 80_000_000 : 40_000_000
-            try? await Task.sleep(nanoseconds: delay)
+            try? await Task.sleep(for: isInteracting ? .milliseconds(80) : .milliseconds(40))
             await refreshVisibleElements()
         }
     }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -546,8 +546,10 @@ struct BoardCanvasView: View {
                     selection.clearSelection()
                     // Defer one run-loop tick so every onAppear handler has
                     // fired and canvasSize is guaranteed non-zero before we
-                    // try to center on content.
-                    Task {
+                    // try to center on content. DispatchQueue.main.async is
+                    // intentional: Task{} uses Swift concurrency's cooperative
+                    // scheduler and doesn't drain the run loop; .main.async does.
+                    DispatchQueue.main.async {
                         if !els.isEmpty {
                             jumpToContentCenter(animated: false)
                         }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -533,7 +533,7 @@ struct BoardCanvasView: View {
             }
             .onChange(of: markCleanTrigger) { _, newValue in
                 guard newValue != nil else { return }
-                Task {
+                Task { @MainActor in
                     await canvasStore.markClean()
                     markCleanTrigger = nil
                 }
@@ -2154,15 +2154,9 @@ struct BoardCanvasView: View {
     private func jumpToContentCenter(animated: Bool = true) {
         guard canvasSize != .zero, camera.scale > 0 else { return }
         let allRects = allElementRects()
-        let centerX: CGFloat
-        let centerY: CGFloat
-        if let bounds = union(of: allRects) {
-            centerX = bounds.midX
-            centerY = bounds.midY
-        } else {
-            centerX = 0
-            centerY = 0
-        }
+        guard let bounds = union(of: allRects) else { return }
+        let centerX = bounds.midX
+        let centerY = bounds.midY
         let target = CGSize(
             width: canvasSize.width / 2 - centerX * camera.scale,
             height: canvasSize.height / 2 - centerY * camera.scale

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -141,45 +141,12 @@ struct BoardCanvasView: View {
             let renderPlan = imageRenderPlan()
             ZStack {
                 // Grid background
-                Canvas { ctx, size in
-                    guard showGrid else { return }
-
-                    let s = camera.scale
-                    let off = camera.offset
-
-                    // Visible world rect
-                    let worldMinX = (-off.width) / s
-                    let worldMinY = (-off.height) / s
-                    let worldMaxX = (size.width - off.width) / s
-                    let worldMaxY = (size.height - off.height) / s
-
-                    // Draw minor grid lines
-                    var path = Path()
-                    let spacing = max(8.0, gridSpacingWorld)
-
-                    // Start lines aligned to world grid
-                    let startX = floor(worldMinX / spacing) * spacing
-                    let startY = floor(worldMinY / spacing) * spacing
-
-                    // Vertical lines
-                    var x = startX
-                    while x <= worldMaxX {
-                        let screenX = x * s + off.width
-                        path.move(to: CGPoint(x: screenX, y: 0))
-                        path.addLine(to: CGPoint(x: screenX, y: size.height))
-                        x += spacing
-                    }
-                    // Horizontal lines
-                    var y = startY
-                    while y <= worldMaxY {
-                        let screenY = y * s + off.height
-                        path.move(to: CGPoint(x: 0, y: screenY))
-                        path.addLine(to: CGPoint(x: size.width, y: screenY))
-                        y += spacing
-                    }
-
-                    ctx.stroke(path, with: .color(.gray.opacity(0.25)), lineWidth: 0.5)
-                }
+                CanvasGridView(
+                    showGrid: showGrid,
+                    scale: camera.scale,
+                    offset: camera.offset,
+                    gridSpacing: gridSpacingWorld
+                )
                 .ignoresSafeArea()
                 .accessibilityHidden(true)
                 .onTapGesture(coordinateSpace: .local) { location in
@@ -202,24 +169,11 @@ struct BoardCanvasView: View {
                 }
 
                 if !renderPlan.overviewItems.isEmpty {
-                    Canvas { ctx, _ in
-                        for item in renderPlan.overviewItems {
-                            let screenRect = CGRect(
-                                x: item.worldRect.origin.x * camera.scale + camera.offset.width,
-                                y: item.worldRect.origin.y * camera.scale + camera.offset.height,
-                                width: item.worldRect.width * camera.scale,
-                                height: item.worldRect.height * camera.scale
-                            )
-                            let fillRect = screenRect.integral.insetBy(dx: 0.25, dy: 0.25)
-                            let fillPath = Path(roundedRect: fillRect, cornerRadius: min(3, min(fillRect.width, fillRect.height) * 0.2))
-                            ctx.fill(fillPath, with: .color(DesignSystem.Colors.secondary.opacity(0.18)))
-                            if fillRect.width >= 6, fillRect.height >= 6 {
-                                ctx.stroke(fillPath, with: .color(DesignSystem.Colors.secondary.opacity(0.32)), lineWidth: 0.75)
-                            }
-                        }
-                    }
-                    .allowsHitTesting(false)
-                    .accessibilityHidden(true)
+                    CanvasOverviewLayer(
+                        items: renderPlan.overviewItems,
+                        scale: camera.scale,
+                        offset: camera.offset
+                    )
                 }
 
                 // Render detailed visible images only (world -> screen mapping)
@@ -435,20 +389,7 @@ struct BoardCanvasView: View {
             }
             .overlay {
                 if placedImages.isEmpty {
-                    VStack(spacing: 16) {
-                        Image(systemName: "photo.on.rectangle.angled")
-                            .font(.system(size: 80))
-                            .foregroundStyle(DesignSystem.Colors.secondary)
-                            .compositingGroup()
-                            .blendMode(.difference)
-                            .accessibilityHidden(true)
-
-                        Text("Drag and drop an image here")
-                            .font(.title3)
-                            .foregroundStyle(DesignSystem.Colors.secondary)
-                            .compositingGroup()
-                            .blendMode(.difference)
-                    }
+                    EmptyCanvasOverlay()
                 }
             }
             .overlay(alignment: .bottomTrailing) {

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -95,6 +95,8 @@ struct BoardCanvasView: View {
 
     // Active tool from toolbar
     @Binding private var activeTool: CanvasTool
+    // Home-button trigger: fires jumpToContentCenter when set to a non-nil UUID
+    @Binding private var homeTrigger: UUID?
     // Selection state
     @State private var selection = CanvasSelectionState()
     @State private var currentDragMode: DragMode? = nil
@@ -117,7 +119,7 @@ struct BoardCanvasView: View {
     @Binding private var markCleanTrigger: UUID?
 
     @MainActor
-    init(activeTool: Binding<CanvasTool> = .constant(.pointer), externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), canvasColor: Binding<Color> = .constant(.white), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), commandHistory: CanvasCommandHistory, undoTrigger: Binding<UUID?> = .constant(nil), redoTrigger: Binding<UUID?> = .constant(nil), markCleanTrigger: Binding<UUID?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement], Bool) -> Void)? = nil) {
+    init(activeTool: Binding<CanvasTool> = .constant(.pointer), externalInsertURLs: Binding<[URL]?> = .constant(nil), showGrid: Binding<Bool> = .constant(true), canvasColor: Binding<Color> = .constant(.white), snapshotTrigger: Binding<UUID?> = .constant(nil), loadElements: Binding<[CMCanvasElement]?> = .constant(nil), commandHistory: CanvasCommandHistory, undoTrigger: Binding<UUID?> = .constant(nil), redoTrigger: Binding<UUID?> = .constant(nil), homeTrigger: Binding<UUID?> = .constant(nil), markCleanTrigger: Binding<UUID?> = .constant(nil), onInsertURLs: @escaping ImportHandler = { _ in }, onSnapshot: (([CMCanvasElement], Bool) -> Void)? = nil) {
         let store = LocalBoardStore()
         self._canvasStore = State(initialValue: store)
         self._activeTool = activeTool
@@ -127,6 +129,7 @@ struct BoardCanvasView: View {
         self.commandHistory = commandHistory
         self._undoTrigger = undoTrigger
         self._redoTrigger = redoTrigger
+        self._homeTrigger = homeTrigger
         self._markCleanTrigger = markCleanTrigger
         self.onInsertURLs = onInsertURLs
         self._snapshotTrigger = snapshotTrigger
@@ -447,6 +450,16 @@ struct BoardCanvasView: View {
                     }
                 }
             }
+            .overlay(alignment: .bottomTrailing) {
+                let rects = allElementRects()
+                if !rects.isEmpty {
+                    CanvasMinimapView(
+                        elementRects: rects,
+                        viewportRect: viewportCGRect()
+                    )
+                    .padding(16)
+                }
+            }
             .onDrop(of: allowedDropTypes, delegate: CanvasDropDelegate(allowedTypes: allowedDropTypes) { point, urls in
                 insertImages(atScreenPoint: point, urls: urls)
             })
@@ -570,6 +583,11 @@ struct BoardCanvasView: View {
                 guard newValue != nil else { return }
                 performRedo()
                 DispatchQueue.main.async { redoTrigger = nil }
+            }
+            .onChange(of: homeTrigger) { _, newValue in
+                guard newValue != nil else { return }
+                jumpToContentCenter()
+                DispatchQueue.main.async { homeTrigger = nil }
             }
             .contentShape(Rectangle())
             // Drag: routed through active tool behavior
@@ -2112,6 +2130,47 @@ struct BoardCanvasView: View {
         guard let first = rects.first else { return nil }
         return rects.dropFirst().reduce(first) { partial, rect in
             partial.union(rect)
+        }
+    }
+
+    /// Current visible viewport expressed as a world-space CGRect.
+    private func viewportCGRect() -> CGRect {
+        guard scale > 0, canvasSize != .zero else { return .zero }
+        let worldMinX = (-offset.width) / scale
+        let worldMinY = (-offset.height) / scale
+        return CGRect(x: worldMinX, y: worldMinY,
+                      width: canvasSize.width / scale,
+                      height: canvasSize.height / scale)
+    }
+
+    /// World-space rects for every element (images + texts) on the canvas.
+    private func allElementRects() -> [CGRect] {
+        var rects = placedImages.map(\.worldRect)
+        rects.append(contentsOf: placedTexts.map(\.worldRect))
+        return rects
+    }
+
+    /// Animate the viewport so the center of all canvas content is centered
+    /// on screen, preserving the current zoom level.
+    private func jumpToContentCenter() {
+        guard canvasSize != .zero, scale > 0 else { return }
+        let allRects = allElementRects()
+        let centerX: CGFloat
+        let centerY: CGFloat
+        if let bounds = union(of: allRects) {
+            centerX = bounds.midX
+            centerY = bounds.midY
+        } else {
+            centerX = 0
+            centerY = 0
+        }
+        withAnimation(.easeInOut(duration: 0.4)) {
+            offset = CGSize(
+                width: canvasSize.width / 2 - centerX * scale,
+                height: canvasSize.height / 2 - centerY * scale
+            )
+        } completion: {
+            scheduleRefreshVisibleElements()
         }
     }
 

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -9,8 +9,7 @@ struct BoardCanvasView: View {
     private let onInsertURLs: ImportHandler
 
     // View transform (world -> screen)
-    @State private var scale: CGFloat = 1.0
-    @State private var offset: CGSize = .zero
+    @State private var camera = CanvasCamera()
 
     // Gesture state
     @State private var dragStartOffset: CGSize? = nil
@@ -146,8 +145,8 @@ struct BoardCanvasView: View {
                 Canvas { ctx, size in
                     guard showGrid else { return }
 
-                    let s = scale
-                    let off = offset
+                    let s = camera.scale
+                    let off = camera.offset
 
                     // Visible world rect
                     let worldMinX = (-off.width) / s
@@ -207,10 +206,10 @@ struct BoardCanvasView: View {
                     Canvas { ctx, _ in
                         for item in renderPlan.overviewItems {
                             let screenRect = CGRect(
-                                x: item.worldRect.origin.x * scale + offset.width,
-                                y: item.worldRect.origin.y * scale + offset.height,
-                                width: item.worldRect.width * scale,
-                                height: item.worldRect.height * scale
+                                x: item.worldRect.origin.x * camera.scale + camera.offset.width,
+                                y: item.worldRect.origin.y * camera.scale + camera.offset.height,
+                                width: item.worldRect.width * camera.scale,
+                                height: item.worldRect.height * camera.scale
                             )
                             let fillRect = screenRect.integral.insetBy(dx: 0.25, dy: 0.25)
                             let fillPath = Path(roundedRect: fillRect, cornerRadius: min(3, min(fillRect.width, fillRect.height) * 0.2))
@@ -244,20 +243,20 @@ struct BoardCanvasView: View {
                         }
                     }()
 
-                    let liveDX = (isSelected && selection.isDragging) ? selection.dragOffset.width * scale : 0
-                    let liveDY = (isSelected && selection.isDragging) ? selection.dragOffset.height * scale : 0
+                    let liveDX = (isSelected && selection.isDragging) ? selection.dragOffset.width * camera.scale : 0
+                    let liveDY = (isSelected && selection.isDragging) ? selection.dragOffset.height * camera.scale : 0
 
                     let multiSelected = selection.selectedIDs.count > 1
 
-                    let maxDimensionPoints = max(liveRect.width * scale, liveRect.height * scale)
+                    let maxDimensionPoints = max(liveRect.width * camera.scale, liveRect.height * camera.scale)
                     let targetMaxPixelSize = FileImageView.requestedThumbnailPixelSize(
                         screenMaxDimensionPoints: maxDimensionPoints,
                         displayScale: displayScale,
                         isInteracting: isInteracting
                     )
                     FileImageView(url: item.url, targetMaxPixelSize: targetMaxPixelSize, isInteracting: isInteracting)
-                        .frame(width: liveRect.width * scale,
-                               height: liveRect.height * scale)
+                        .frame(width: liveRect.width * camera.scale,
+                               height: liveRect.height * camera.scale)
                         .overlay {
                             if isSelected && !multiSelected {
                                 SelectionOverlay(activeHandle: selection.resizeHandle)
@@ -277,8 +276,8 @@ struct BoardCanvasView: View {
                                 await refreshVisibleElements()
                             }
                         }
-                        .position(x: (liveRect.midX * scale) + offset.width + liveDX,
-                                  y: (liveRect.midY * scale) + offset.height + liveDY)
+                        .position(x: (liveRect.midX * camera.scale) + camera.offset.width + liveDX,
+                                  y: (liveRect.midY * camera.scale) + camera.offset.height + liveDY)
                         .shadow(radius: isInteracting ? 0 : 1)
                         .zIndex(Double(item.zIndex))
                 }
@@ -294,22 +293,22 @@ struct BoardCanvasView: View {
                 ForEach($placedTexts) { $placed in
                     let isSelected = selection.selectedIDs.contains(placed.id)
                     let isMultiSelected = selection.selectedIDs.count > 1
-                    let liveDX = (isSelected && selection.isDragging) ? selection.dragOffset.width * scale : 0
-                    let liveDY = (isSelected && selection.isDragging) ? selection.dragOffset.height * scale : 0
+                    let liveDX = (isSelected && selection.isDragging) ? selection.dragOffset.width * camera.scale : 0
+                    let liveDY = (isSelected && selection.isDragging) ? selection.dragOffset.height * camera.scale : 0
                     let id = placed.id
                     let isEditing = editingTextID == id
 
                     TextElementView(
                         placed: $placed,
-                        scale: scale,
+                        scale: camera.scale,
                         isEditing: isEditing,
                         isSelected: isSelected,
                         isMultiSelected: isMultiSelected,
                         onCommitEdit: { commitTextEdit(id: id) }
                     )
                     .position(
-                        x: (placed.worldRect.midX * scale) + offset.width + liveDX,
-                        y: (placed.worldRect.midY * scale) + offset.height + liveDY
+                        x: (placed.worldRect.midX * camera.scale) + camera.offset.width + liveDX,
+                        y: (placed.worldRect.midY * camera.scale) + camera.offset.height + liveDY
                     )
                     .onTapGesture {
                         // Tap-on-sole-selected text → re-enter edit mode.
@@ -339,10 +338,10 @@ struct BoardCanvasView: View {
                 // Marquee selection rectangle
                 if selection.isMarqueeing, let worldRect = selection.marqueeWorldRect {
                     let screenRect = CGRect(
-                        x: worldRect.origin.x * scale + offset.width,
-                        y: worldRect.origin.y * scale + offset.height,
-                        width: worldRect.width * scale,
-                        height: worldRect.height * scale
+                        x: worldRect.origin.x * camera.scale + camera.offset.width,
+                        y: worldRect.origin.y * camera.scale + camera.offset.height,
+                        width: worldRect.width * camera.scale,
+                        height: worldRect.height * camera.scale
                     )
                     MarqueeOverlayView(screenRect: screenRect)
                         .allowsHitTesting(false)
@@ -364,10 +363,10 @@ struct BoardCanvasView: View {
                    !selection.isDragging,
                    !selection.isMarqueeing {
                     let screenRect = CGRect(
-                        x: placed.worldRect.origin.x * scale + offset.width,
-                        y: placed.worldRect.origin.y * scale + offset.height,
-                        width: placed.worldRect.width * scale,
-                        height: placed.worldRect.height * scale
+                        x: placed.worldRect.origin.x * camera.scale + camera.offset.width,
+                        y: placed.worldRect.origin.y * camera.scale + camera.offset.height,
+                        width: placed.worldRect.width * camera.scale,
+                        height: placed.worldRect.height * camera.scale
                     )
                     SelectionOverlay(
                         handles: TextElementView.textHandles,
@@ -387,10 +386,10 @@ struct BoardCanvasView: View {
                 if let editingID = editingTextID,
                    let placed = placedTexts.first(where: { $0.id == editingID }) {
                     let screenRect = CGRect(
-                        x: placed.worldRect.origin.x * scale + offset.width,
-                        y: placed.worldRect.origin.y * scale + offset.height,
-                        width: placed.worldRect.width * scale,
-                        height: placed.worldRect.height * scale
+                        x: placed.worldRect.origin.x * camera.scale + camera.offset.width,
+                        y: placed.worldRect.origin.y * camera.scale + camera.offset.height,
+                        width: placed.worldRect.width * camera.scale,
+                        height: placed.worldRect.height * camera.scale
                     )
                     Rectangle()
                         .strokeBorder(DesignSystem.Colors.tertiary, lineWidth: 1.5)
@@ -403,8 +402,8 @@ struct BoardCanvasView: View {
                 // Floating action bar beneath the current selection.
                 SelectionActionBarLayer(
                     boundingBox: selectionBoundingBox(),
-                    scale: scale,
-                    offset: offset,
+                    scale: camera.scale,
+                    offset: camera.offset,
                     isInteracting: selection.isDragging
                         || selection.isResizing
                         || selection.isGroupResizing
@@ -420,10 +419,10 @@ struct BoardCanvasView: View {
                         : groupBoundingBox()
                     if let bbox {
                         let screenRect = CGRect(
-                            x: bbox.origin.x * scale + offset.width,
-                            y: bbox.origin.y * scale + offset.height,
-                            width: bbox.width * scale,
-                            height: bbox.height * scale
+                            x: bbox.origin.x * camera.scale + camera.offset.width,
+                            y: bbox.origin.y * camera.scale + camera.offset.height,
+                            width: bbox.width * camera.scale,
+                            height: bbox.height * camera.scale
                         )
                         GroupSelectionOverlay(activeHandle: selection.resizeHandle)
                             .frame(width: screenRect.width, height: screenRect.height)
@@ -470,8 +469,8 @@ struct BoardCanvasView: View {
             .onAppear {
                 canvasSize = geo.size
                 // Center the canvas on world origin (0, 0) on first appearance
-                if offset == .zero {
-                    offset = CGSize(width: geo.size.width / 2, height: geo.size.height / 2)
+                if camera.offset == .zero {
+                    camera.offset = CGSize(width: geo.size.width / 2, height: geo.size.height / 2)
                 }
                 // If elements were already applied before canvasSize was available
                 // (ContentView.onAppear fired before this onAppear), snap to content
@@ -641,7 +640,7 @@ struct BoardCanvasView: View {
                                 currentDragMode = DragMode.none
                                 return
                             }
-                            dragStartOffset = offset
+                            dragStartOffset = camera.offset
 
                             if let hitResult = hitTestHandle(screenPoint: value.startLocation) {
                                 switch hitResult {
@@ -745,26 +744,6 @@ struct BoardCanvasView: View {
         min(max(value, minVal), maxVal)
     }
 
-    /// Pure function: compute the new `offset` that keeps the world point under
-    /// `anchor` (in screen-space points) fixed while scale changes from `oldScale`
-    /// to `newScale`. Extracted from `handlePinch` so the pivot-preserving math is
-    /// callable without a live view (e.g. from future unit tests).
-    ///
-    /// Preserves `worldPoint = (anchor - offset) / scale` across the zoom step.
-    static func zoomAnchoredOffset(
-        anchor: CGPoint,
-        oldOffset: CGSize,
-        oldScale: CGFloat,
-        newScale: CGFloat
-    ) -> CGSize {
-        let worldXBefore = (anchor.x - oldOffset.width) / oldScale
-        let worldYBefore = (anchor.y - oldOffset.height) / oldScale
-        return CGSize(
-            width: anchor.x - worldXBefore * newScale,
-            height: anchor.y - worldYBefore * newScale
-        )
-    }
-
     private func startInteraction() {
         interactionEndTask?.cancel()
         if !isInteracting {
@@ -785,20 +764,20 @@ struct BoardCanvasView: View {
         case .began:
             startInteraction()
         case .changed:
-            let newScale = clamp(scale * scaleDelta, minScale, maxScale)
+            let newScale = clamp(camera.scale * scaleDelta, minScale, maxScale)
             // Clamp can cancel the delta; skip to avoid unnecessary offset churn.
-            guard newScale != scale else { return }
+            guard newScale != camera.scale else { return }
             // Pivot-preserving zoom: keep the world point currently under `anchor`
             // pinned to the same screen position after the scale change. Reading
-            // `offset`/`scale` fresh every tick is what lets this compose with the
-            // simultaneous two-finger pan (no frozen baselines to clobber).
-            offset = Self.zoomAnchoredOffset(
+            // `camera.offset`/`camera.scale` fresh every tick is what lets this
+            // compose with the simultaneous two-finger pan (no frozen baselines).
+            camera.offset = CanvasCamera.zoomAnchoredOffset(
                 anchor: anchor,
-                oldOffset: offset,
-                oldScale: scale,
+                oldOffset: camera.offset,
+                oldScale: camera.scale,
                 newScale: newScale
             )
-            scale = newScale
+            camera.scale = newScale
             scheduleRefreshVisibleElements()
         case .ended:
             endInteraction()
@@ -810,8 +789,8 @@ struct BoardCanvasView: View {
         case .began:
             startInteraction()
         case .changed:
-            offset = CGSize(width: offset.width + delta.width,
-                            height: offset.height + delta.height)
+            camera.offset = CGSize(width: camera.offset.width + delta.width,
+                                   height: camera.offset.height + delta.height)
             scheduleRefreshVisibleElements()
         case .ended:
             endInteraction()
@@ -841,10 +820,10 @@ struct BoardCanvasView: View {
            textIDs.contains(selectedID),
            let text = placedTexts.first(where: { $0.id == selectedID }) {
             let textScreenRect = CGRect(
-                x: text.worldRect.origin.x * scale + offset.width,
-                y: text.worldRect.origin.y * scale + offset.height,
-                width: text.worldRect.width * scale,
-                height: text.worldRect.height * scale
+                x: text.worldRect.origin.x * camera.scale + camera.offset.width,
+                y: text.worldRect.origin.y * camera.scale + camera.offset.height,
+                width: text.worldRect.width * camera.scale,
+                height: text.worldRect.height * camera.scale
             )
             if let handle = hitTestHandleOnRect(screenPoint: screenPoint, screenRect: textScreenRect),
                handle != .topCenter && handle != .bottomCenter {
@@ -859,20 +838,20 @@ struct BoardCanvasView: View {
            let selectedID = selection.selectedIDs.first,
            let item = visibleImages.first(where: { $0.id == selectedID }) {
             let itemScreenRect = CGRect(
-                x: item.worldRect.origin.x * scale + offset.width,
-                y: item.worldRect.origin.y * scale + offset.height,
-                width: item.worldRect.width * scale,
-                height: item.worldRect.height * scale
+                x: item.worldRect.origin.x * camera.scale + camera.offset.width,
+                y: item.worldRect.origin.y * camera.scale + camera.offset.height,
+                width: item.worldRect.width * camera.scale,
+                height: item.worldRect.height * camera.scale
             )
             if let handle = hitTestHandleOnRect(screenPoint: screenPoint, screenRect: itemScreenRect) {
                 return .singleItem(handle: handle, item: item)
             }
         } else if selection.selectedIDs.count > 1, let bbox = groupBoundingBox() {
             let bboxScreenRect = CGRect(
-                x: bbox.origin.x * scale + offset.width,
-                y: bbox.origin.y * scale + offset.height,
-                width: bbox.width * scale,
-                height: bbox.height * scale
+                x: bbox.origin.x * camera.scale + camera.offset.width,
+                y: bbox.origin.y * camera.scale + camera.offset.height,
+                width: bbox.width * camera.scale,
+                height: bbox.height * camera.scale
             )
             if let handle = hitTestHandleOnRect(screenPoint: screenPoint, screenRect: bboxScreenRect) {
                 return .group(handle: handle, bbox: bbox)
@@ -922,10 +901,10 @@ struct BoardCanvasView: View {
 
         for item in visibleImages {
             let screenRect = CGRect(
-                x: item.worldRect.origin.x * scale + offset.width,
-                y: item.worldRect.origin.y * scale + offset.height,
-                width: item.worldRect.width * scale,
-                height: item.worldRect.height * scale
+                x: item.worldRect.origin.x * camera.scale + camera.offset.width,
+                y: item.worldRect.origin.y * camera.scale + camera.offset.height,
+                width: item.worldRect.width * camera.scale,
+                height: item.worldRect.height * camera.scale
             )
             let screenMaxDimension = max(screenRect.width, screenRect.height)
             let screenArea = max(screenRect.width * screenRect.height, 0)
@@ -992,14 +971,14 @@ struct BoardCanvasView: View {
         switch mode {
         case .pan:
             guard let start = dragStartOffset else { return }
-            offset = CGSize(
+            camera.offset = CGSize(
                 width: start.width + value.translation.width,
                 height: start.height + value.translation.height
             )
             scheduleRefreshVisibleElements()
         case .moveItem:
-            let worldDX = value.translation.width / scale
-            let worldDY = value.translation.height / scale
+            let worldDX = value.translation.width / camera.scale
+            let worldDY = value.translation.height / camera.scale
             selection.dragOffset = CGSize(width: worldDX, height: worldDY)
             selection.isDragging = true
         case .resizeItem:
@@ -1035,8 +1014,8 @@ struct BoardCanvasView: View {
         translation: CGSize,
         minDimension: CGFloat? = nil
     ) -> CGRect? {
-        let worldDX = translation.width / scale
-        let worldDY = translation.height / scale
+        let worldDX = translation.width / camera.scale
+        let worldDY = translation.height / camera.scale
         let minDim = minDimension ?? minImageDimensionWorld
 
         let anchorPos = handle.anchorPosition
@@ -1368,7 +1347,7 @@ struct BoardCanvasView: View {
             // Reference width: existing wrapWidth if set, else current
             // measured worldRect.width (auto-width text).
             let baseWidth = startWrapWidth ?? startRect.width
-            let worldDX = translation.width / scale
+            let worldDX = translation.width / camera.scale
             let newWrap = max(minTextWrapWidth, baseWidth + worldDX)
             placedTexts[idx].wrapWidth = newWrap
             // Origin unchanged — left edge is anchor.
@@ -1376,7 +1355,7 @@ struct BoardCanvasView: View {
             // Left edge drag → set wrap width AND shift origin so the right
             // edge stays anchored (Figma convention).
             let baseWidth = startWrapWidth ?? startRect.width
-            let worldDX = translation.width / scale
+            let worldDX = translation.width / camera.scale
             let newWrap = max(minTextWrapWidth, baseWidth - worldDX)
             placedTexts[idx].wrapWidth = newWrap
             // Right edge anchored at startRect.maxX; origin = right - newWrap.
@@ -1868,8 +1847,8 @@ struct BoardCanvasView: View {
     }
 
     private func currentViewportRect() -> CMWorldRect {
-        let s = Double(scale)
-        let off = offset
+        let s = Double(camera.scale)
+        let off = camera.offset
         let worldMinX = (-off.width) / CGFloat(s)
         let worldMinY = (-off.height) / CGFloat(s)
         let worldMaxX = (canvasSize.width - off.width) / CGFloat(s)
@@ -1890,7 +1869,7 @@ struct BoardCanvasView: View {
     }
 
     private func visibleQueryMargin() -> Double {
-        let zoomAwareMargin = Double(256 * max(scale, 0.25))
+        let zoomAwareMargin = Double(256 * max(camera.scale, 0.25))
         return min(maxVisibleQueryMargin, max(minVisibleQueryMargin, zoomAwareMargin))
     }
 
@@ -1930,7 +1909,8 @@ struct BoardCanvasView: View {
     }
 
     private func screenToWorld(_ p: CGPoint) -> CGPoint {
-        CGPoint(x: (p.x - offset.width) / scale, y: (p.y - offset.height) / scale)
+        CGPoint(x: (p.x - camera.offset.width) / camera.scale,
+                y: (p.y - camera.offset.height) / camera.scale)
     }
 
     private func imagePixelSize(url: URL) -> CGSize? {
@@ -2153,12 +2133,12 @@ struct BoardCanvasView: View {
 
     /// Current visible viewport expressed as a world-space CGRect.
     private func viewportCGRect() -> CGRect {
-        guard scale > 0, canvasSize != .zero else { return .zero }
-        let worldMinX = (-offset.width) / scale
-        let worldMinY = (-offset.height) / scale
+        guard camera.scale > 0, canvasSize != .zero else { return .zero }
+        let worldMinX = (-camera.offset.width) / camera.scale
+        let worldMinY = (-camera.offset.height) / camera.scale
         return CGRect(x: worldMinX, y: worldMinY,
-                      width: canvasSize.width / scale,
-                      height: canvasSize.height / scale)
+                      width: canvasSize.width / camera.scale,
+                      height: canvasSize.height / camera.scale)
     }
 
     /// World-space rects for every element (images + texts) on the canvas.
@@ -2172,7 +2152,7 @@ struct BoardCanvasView: View {
     /// instant repositioning (e.g. on board load); `true` for the home button
     /// eased pan.
     private func jumpToContentCenter(animated: Bool = true) {
-        guard canvasSize != .zero, scale > 0 else { return }
+        guard canvasSize != .zero, camera.scale > 0 else { return }
         let allRects = allElementRects()
         let centerX: CGFloat
         let centerY: CGFloat
@@ -2184,17 +2164,17 @@ struct BoardCanvasView: View {
             centerY = 0
         }
         let target = CGSize(
-            width: canvasSize.width / 2 - centerX * scale,
-            height: canvasSize.height / 2 - centerY * scale
+            width: canvasSize.width / 2 - centerX * camera.scale,
+            height: canvasSize.height / 2 - centerY * camera.scale
         )
         if animated && !reduceMotion {
             withAnimation(.easeInOut(duration: 0.4)) {
-                offset = target
+                camera.offset = target
             } completion: {
                 scheduleRefreshVisibleElements()
             }
         } else {
-            offset = target
+            camera.offset = target
             scheduleRefreshVisibleElements()
         }
     }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -22,6 +22,7 @@ struct BoardCanvasView: View {
     @Binding private var canvasColor: Color
     @State private var gridSpacingWorld: CGFloat = 128.0
     @Environment(\.displayScale) private var displayScale
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Placed images (source-of-truth for interactions)
     @State private var placedImages: [PlacedImage] = []
@@ -476,7 +477,7 @@ struct BoardCanvasView: View {
                 // (ContentView.onAppear fired before this onAppear), snap to content
                 // center now that canvasSize is known. jumpToContentCenter also calls
                 // scheduleRefreshVisibleElements, so skip the standalone call below.
-                if !allElementRects().isEmpty {
+                if !placedImages.isEmpty || !placedTexts.isEmpty {
                     jumpToContentCenter(animated: false)
                 } else {
                     scheduleRefreshVisibleElements()
@@ -533,8 +534,10 @@ struct BoardCanvasView: View {
             }
             .onChange(of: markCleanTrigger) { _, newValue in
                 guard newValue != nil else { return }
-                Task { await canvasStore.markClean() }
-                DispatchQueue.main.async { markCleanTrigger = nil }
+                Task {
+                    await canvasStore.markClean()
+                    markCleanTrigger = nil
+                }
             }
             .onChange(of: elementsToLoad) { oldValue, newValue in
                 if let els = newValue {
@@ -544,7 +547,7 @@ struct BoardCanvasView: View {
                     // Defer one run-loop tick so every onAppear handler has
                     // fired and canvasSize is guaranteed non-zero before we
                     // try to center on content.
-                    DispatchQueue.main.async {
+                    Task {
                         if !els.isEmpty {
                             jumpToContentCenter(animated: false)
                         }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -2187,7 +2187,7 @@ struct BoardCanvasView: View {
             width: canvasSize.width / 2 - centerX * scale,
             height: canvasSize.height / 2 - centerY * scale
         )
-        if animated {
+        if animated && !reduceMotion {
             withAnimation(.easeInOut(duration: 0.4)) {
                 offset = target
             } completion: {

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/BoardCanvasView.swift
@@ -472,7 +472,15 @@ struct BoardCanvasView: View {
                 if offset == .zero {
                     offset = CGSize(width: geo.size.width / 2, height: geo.size.height / 2)
                 }
-                scheduleRefreshVisibleElements()
+                // If elements were already applied before canvasSize was available
+                // (ContentView.onAppear fired before this onAppear), snap to content
+                // center now that canvasSize is known. jumpToContentCenter also calls
+                // scheduleRefreshVisibleElements, so skip the standalone call below.
+                if !allElementRects().isEmpty {
+                    jumpToContentCenter(animated: false)
+                } else {
+                    scheduleRefreshVisibleElements()
+                }
             }
             .onDisappear {
                 refreshTask?.cancel()
@@ -533,11 +541,13 @@ struct BoardCanvasView: View {
                     applyElements(els)
                     commandHistory.clear()
                     selection.clearSelection()
-                    if !els.isEmpty {
-                        jumpToContentCenter(animated: false)
-                    }
-                    // Clear the binding after applying
+                    // Defer one run-loop tick so every onAppear handler has
+                    // fired and canvasSize is guaranteed non-zero before we
+                    // try to center on content.
                     DispatchQueue.main.async {
+                        if !els.isEmpty {
+                            jumpToContentCenter(animated: false)
+                        }
                         elementsToLoad = nil
                     }
                 }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCamera.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCamera.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// home button, landing snap) go through one place, and the type can be
 /// injected or observed independently of the view in future refactors.
 @Observable
+@MainActor
 final class CanvasCamera {
     var offset: CGSize = .zero
     var scale: CGFloat = 1.0

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCamera.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasCamera.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Encapsulates the two degrees of freedom that define where the canvas
+/// camera is pointing: a translation offset (world-origin → screen-center)
+/// and a uniform zoom scale.
+///
+/// Extracted from `BoardCanvasView` so all four write sites (pinch, pan,
+/// home button, landing snap) go through one place, and the type can be
+/// injected or observed independently of the view in future refactors.
+@Observable
+final class CanvasCamera {
+    var offset: CGSize = .zero
+    var scale: CGFloat = 1.0
+
+    /// Pivot-preserving zoom: compute the new `offset` that keeps the world
+    /// point currently under `anchor` (screen-space) pinned after scale changes.
+    ///
+    /// Invariant: `worldPoint = (anchor - offset) / scale` must equal
+    /// `(anchor - newOffset) / newScale`.
+    static func zoomAnchoredOffset(
+        anchor: CGPoint,
+        oldOffset: CGSize,
+        oldScale: CGFloat,
+        newScale: CGFloat
+    ) -> CGSize {
+        let worldX = (anchor.x - oldOffset.width) / oldScale
+        let worldY = (anchor.y - oldOffset.height) / oldScale
+        return CGSize(
+            width: anchor.x - worldX * newScale,
+            height: anchor.y - worldY * newScale
+        )
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasGridView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasGridView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Draws the infinite dot-grid background for the canvas. The canvas always
+/// occupies the full view (so hit-testing on the empty canvas tap gesture is
+/// consistent), but draws nothing when `showGrid` is false.
+struct CanvasGridView: View {
+    let showGrid: Bool
+    let scale: CGFloat
+    let offset: CGSize
+    let gridSpacing: CGFloat
+
+    var body: some View {
+        Canvas { ctx, size in
+            guard showGrid else { return }
+
+            let worldMinX = (-offset.width) / scale
+            let worldMinY = (-offset.height) / scale
+            let worldMaxX = (size.width - offset.width) / scale
+            let worldMaxY = (size.height - offset.height) / scale
+
+            var path = Path()
+            let spacing = max(8.0, gridSpacing)
+            let startX = floor(worldMinX / spacing) * spacing
+            let startY = floor(worldMinY / spacing) * spacing
+
+            var x = startX
+            while x <= worldMaxX {
+                let screenX = x * scale + offset.width
+                path.move(to: CGPoint(x: screenX, y: 0))
+                path.addLine(to: CGPoint(x: screenX, y: size.height))
+                x += spacing
+            }
+            var y = startY
+            while y <= worldMaxY {
+                let screenY = y * scale + offset.height
+                path.move(to: CGPoint(x: 0, y: screenY))
+                path.addLine(to: CGPoint(x: size.width, y: screenY))
+                y += spacing
+            }
+
+            ctx.stroke(path, with: .color(.gray.opacity(0.25)), lineWidth: 0.5)
+        }
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasGridView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasGridView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Draws the infinite dot-grid background for the canvas. The canvas always
+/// Draws the infinite line-grid background for the canvas. The canvas always
 /// occupies the full view (so hit-testing on the empty canvas tap gesture is
 /// consistent), but draws nothing when `showGrid` is false.
 struct CanvasGridView: View {

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasMinimapView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasMinimapView.swift
@@ -29,7 +29,7 @@ struct CanvasMinimapView: View {
         }
         .frame(width: 160, height: 100)
         .background {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
+            RoundedRectangle(cornerRadius: 10)
                 .fill(.black.opacity(0.55))
                 .stroke(.white.opacity(0.12), lineWidth: 0.5)
         }

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasMinimapView.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasMinimapView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Compact semi-transparent minimap rendered in the bottom-right corner of the
+/// canvas. Shows element positions (white rectangles) and the current viewport
+/// (blue outline) relative to the full content extents.
+struct CanvasMinimapView: View {
+    let elementRects: [CGRect]
+    let viewportRect: CGRect
+
+    var body: some View {
+        Canvas { ctx, size in
+            guard !elementRects.isEmpty else { return }
+            let world = worldExtents()
+            guard world.width > 0.001, world.height > 0.001 else { return }
+
+            for rect in elementRects {
+                let mr = project(rect, world: world, into: size)
+                let drawn = CGRect(x: mr.minX, y: mr.minY,
+                                   width: max(2, mr.width), height: max(2, mr.height))
+                ctx.fill(Path(roundedRect: drawn, cornerRadius: 1),
+                         with: .color(.white.opacity(0.7)))
+            }
+
+            let vr = project(viewportRect, world: world, into: size)
+            ctx.fill(Path(vr), with: .color(.white.opacity(0.08)))
+            ctx.stroke(Path(vr),
+                       with: .color(DesignSystem.Colors.tertiary.opacity(0.9)),
+                       lineWidth: 1.5)
+        }
+        .frame(width: 160, height: 100)
+        .background {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(.black.opacity(0.55))
+                .stroke(.white.opacity(0.12), lineWidth: 0.5)
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func worldExtents() -> CGRect {
+        guard let first = elementRects.first else { return viewportRect }
+        var bounds = first
+        for rect in elementRects.dropFirst() { bounds = bounds.union(rect) }
+        bounds = bounds.union(viewportRect)
+        let padX = max(64, bounds.width * 0.12)
+        let padY = max(64, bounds.height * 0.12)
+        return bounds.insetBy(dx: -padX, dy: -padY)
+    }
+
+    private func project(_ rect: CGRect, world: CGRect, into size: CGSize) -> CGRect {
+        let sx = size.width / world.width
+        let sy = size.height / world.height
+        return CGRect(
+            x: (rect.minX - world.minX) * sx,
+            y: (rect.minY - world.minY) * sy,
+            width: rect.width * sx,
+            height: rect.height * sy
+        )
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasOverviewLayer.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/CanvasOverviewLayer.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Renders thumbnail-scale placeholder rectangles for images that are below
+/// the detail LOD threshold — too small or too numerous to decode at full
+/// fidelity. Drawn in a single `Canvas` pass so there's one layer per frame
+/// rather than one view per image.
+struct CanvasOverviewLayer: View {
+    let items: [PlacedImage]
+    let scale: CGFloat
+    let offset: CGSize
+
+    var body: some View {
+        Canvas { ctx, _ in
+            for item in items {
+                let screenRect = CGRect(
+                    x: item.worldRect.origin.x * scale + offset.width,
+                    y: item.worldRect.origin.y * scale + offset.height,
+                    width: item.worldRect.width * scale,
+                    height: item.worldRect.height * scale
+                )
+                let fillRect = screenRect.integral.insetBy(dx: 0.25, dy: 0.25)
+                let fillPath = Path(
+                    roundedRect: fillRect,
+                    cornerRadius: min(3, min(fillRect.width, fillRect.height) * 0.2)
+                )
+                ctx.fill(fillPath, with: .color(DesignSystem.Colors.secondary.opacity(0.18)))
+                if fillRect.width >= 6, fillRect.height >= 6 {
+                    ctx.stroke(
+                        fillPath,
+                        with: .color(DesignSystem.Colors.secondary.opacity(0.32)),
+                        lineWidth: 0.75
+                    )
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/EmptyCanvasOverlay.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/EmptyCanvasOverlay.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Hint shown when the board has no images yet. Uses `.difference` blend so
+/// it stays readable against both light and dark canvas backgrounds.
+struct EmptyCanvasOverlay: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 80))
+                .foregroundStyle(DesignSystem.Colors.secondary)
+                .compositingGroup()
+                .blendMode(.difference)
+                .accessibilityHidden(true)
+
+            Text("Drag and drop an image here")
+                .font(.title3)
+                .foregroundStyle(DesignSystem.Colors.secondary)
+                .compositingGroup()
+                .blendMode(.difference)
+        }
+    }
+}

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/Tools/CanvasNavigationToolbar.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/Tools/CanvasNavigationToolbar.swift
@@ -25,6 +25,7 @@ struct CanvasNavigationToolbar: ToolbarContent {
     let onBack: () -> Void
     let onUndo: () -> Void
     let onRedo: () -> Void
+    let onHome: () -> Void
     let onAddItem: () -> Void
     let onSettings: () -> Void
 
@@ -71,6 +72,7 @@ struct CanvasNavigationToolbar: ToolbarContent {
             Button(action: onRedo) {
                 Label("Redo", systemImage: "arrow.uturn.forward")
             }
+            Button("Go to Content", systemImage: "house", action: onHome)
         }
 
         ToolbarSpacer(.fixed, placement: .topBarTrailing)

--- a/SuperCoolArtReferenceTool/Features/BoardCanvas/Tools/CanvasNavigationToolbar.swift
+++ b/SuperCoolArtReferenceTool/Features/BoardCanvas/Tools/CanvasNavigationToolbar.swift
@@ -13,10 +13,11 @@ import SwiftUI
 ///
 /// Layout:
 /// - Leading group: back chevron + board name pill (no nested glass).
-/// - Trailing: tools+add / undo-redo / settings, split by `ToolbarSpacer`
+/// - Trailing: tools+add / undo-redo / home+settings, split by `ToolbarSpacer`
 ///   so each group renders as its own glass capsule. Add lives with the
 ///   tools because it's the other put-stuff-on-the-canvas action, not a
-///   settings affordance.
+///   settings affordance. Home lives with settings because both are
+///   view-level navigation, not edit-history actions.
 /// - All buttons use `Label("Title", systemImage: …)` so the system overflow
 ///   menu can populate from titles when the bar collapses.
 struct CanvasNavigationToolbar: ToolbarContent {
@@ -72,12 +73,12 @@ struct CanvasNavigationToolbar: ToolbarContent {
             Button(action: onRedo) {
                 Label("Redo", systemImage: "arrow.uturn.forward")
             }
-            Button("Go to Content", systemImage: "house", action: onHome)
         }
 
         ToolbarSpacer(.fixed, placement: .topBarTrailing)
 
-        ToolbarItem(placement: .topBarTrailing) {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            Button("Go to Content", systemImage: "house", action: onHome)
             Button(action: onSettings) {
                 Label("Settings", systemImage: "gear")
             }

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -32,14 +32,20 @@ The canvas system is implemented as a standalone, reusable SwiftUI component tha
 - World units are arbitrary but consistent (currently ~1 unit per screen point at 1.0 scale)
 
 **Camera/Transform Model:**
-- `offset: CGSize` - Translation from world origin to screen space (in screen points)
-- `scale: CGFloat` - Uniform scale factor (zoom level)
+
+Camera state is encapsulated in `@Observable final class CanvasCamera` (`CanvasCamera.swift`), owned as `@State private var camera = CanvasCamera()` inside `BoardCanvasView`.
+
+- `camera.offset: CGSize` — Translation from world origin to screen space (in screen points)
+- `camera.scale: CGFloat` — Uniform scale factor (zoom level)
 - Bounds: `minScale = 0.05`, `maxScale = 8.0`
-- Transform: `screenPoint = worldPoint * scale + offset`
+- Transform: `screenPoint = worldPoint * camera.scale + camera.offset`
+
+Write sites: pinch gesture, two-finger pan, home button (`jumpToContentCenter`), board-load landing snap. All go through `camera.offset` / `camera.scale`.
 
 **Initial View:**
-- On `.onAppear`, offset is set to `(screenWidth/2, screenHeight/2)` to center world origin
-- Note: Canvas view may not update immediately; visible after first pan gesture
+- On `.onAppear`, `camera.offset` is set to `(screenWidth/2, screenHeight/2)` to center on world origin
+- If elements are already loaded when `onAppear` fires (race with `ContentView.onAppear`), `jumpToContentCenter(animated: false)` runs immediately instead, centering on content
+- When a board with content is loaded via `elementsToLoad`, `jumpToContentCenter(animated: false)` is deferred one run-loop tick via `DispatchQueue.main.async` to guarantee `canvasSize` is set first (see "Landing Snap" under Canvas Navigation Aids below)
 
 **Coordinate Conversion:**
 Implemented via `screenToWorld(_:)` helper:
@@ -54,7 +60,7 @@ func screenToWorld(_ p: CGPoint) -> CGPoint {
 - Canvas rendered using SwiftUI `Canvas` for grid background
 - Items rendered as SwiftUI views in a `ZStack` with `.zIndex()` for layering
 - Transform applied via `.position()` and `.frame()` modifiers
-- Currently no visibility culling (all items rendered); acceptable for MVP with small item counts
+- Viewport culling via `visibleImages` (tile-indexed spatial query against `LocalBoardStore`); images outside the viewport are not rendered
 
 **Grid Visualization:**
 - World-aligned grid with configurable spacing (`gridSpacingWorld = 128.0`)
@@ -97,7 +103,7 @@ Three simultaneous gestures are attached to the canvas ZStack:
 - Emits **per-tick scale deltas** (not cumulative) plus the **live centroid** in installer-local coordinates. `.began`/`.ended` emit delta = 1.0; only `.changed` emits real deltas.
 - Centroid is reported in the installer's coordinate space (not `recognizer.view` / window space) so it matches the canvas's `.position(...)` space — important if the canvas is ever inset by a toolbar or safe area.
 - Attached via `.background(PinchGestureView(onPinch:))` on the canvas ZStack; routed through `handlePinch(phase:scaleDelta:anchor:)`.
-- Zoom math is extracted into a **pure static function**, `BoardCanvasView.zoomAnchoredOffset(anchor:oldOffset:oldScale:newScale:)`, which preserves `worldPoint = (anchor - offset) / scale` across the scale change. Testable without a live view.
+- Zoom math is extracted into a **pure static function**, `CanvasCamera.zoomAnchoredOffset(anchor:oldOffset:oldScale:newScale:)` (lives in `CanvasCamera.swift`), which preserves `worldPoint = (anchor - offset) / scale` across the scale change. Testable without a live view.
 
 **Two-Finger Pan (UIKit Bridge):**
 
@@ -121,15 +127,15 @@ Pinch and two-finger-pan fire simultaneously and both write `offset`. An earlier
 - Consumers (pinch + two-finger pan today) conform their `Coordinator` to `GestureInstallerCoordinator` and expose their recognizer via `installedRecognizer`.
 - Teardown: each bridge's `dismantleUIView(_:coordinator:)` calls `Coordinator.detach()`, which removes the recognizer from its host view, clears target/delegate, and replaces the event closure with a no-op — prevents duplicate recognizers and retention cycles if the canvas remounts (e.g. `RootView` toggling `showCanvas`).
 
-**Camera model tipping point — refactor now due:**
+**Camera model — implemented:**
 
-`offset` and `scale` currently live on `BoardCanvasView` as `@State`. They now have **four write sites**: pinch gesture, two-finger-pan gesture, home button (`jumpToContentCenter`), and board-load landing snap (`onChange(of: elementsToLoad)`). The original flag said to lift when a third site appeared; that threshold has been crossed.
+`offset` and `scale` have been lifted into `@Observable final class CanvasCamera` (`CanvasCamera.swift`). `BoardCanvasView` owns it as `@State private var camera = CanvasCamera()`. `zoomAnchoredOffset` is a static method on `CanvasCamera`.
 
-Target shape: extract an `@Observable class CanvasCamera` (or `@Observable struct` + `@State`) with `zoom(by:around:)`, `pan(by:)`, and `jumpToCenter(of:animated:)` methods. `zoomAnchoredOffset` and `jumpToContentCenter` move in as methods. `viewportCGRect()` and `allElementRects()` stay on the view (they need view-local state like `canvasSize` and `placedImages`), but the camera itself becomes injectable/testable independently.
+`viewportCGRect()` and `allElementRects()` remain on `BoardCanvasView` — they need view-local state (`canvasSize`, `placedImages`, `placedTexts`) that belongs on the view.
 
-Downstream: the UUID-trigger pattern for `homeTrigger` (and potentially `undoTrigger`/`redoTrigger`) could simplify once the camera is a shared observable — the toolbar can call `canvasCamera.jumpToCenter()` directly instead of firing a UUID binding through ContentView.
+`jumpToContentCenter` also remains on the view (needs `canvasSize`, `reduceMotion`, `scheduleRefreshVisibleElements()`), but writes to `camera.offset`.
 
-This is a cross-cutting change; do it as a standalone PR before adding more camera-writing features.
+Next step (future PR): the UUID-trigger pattern for `homeTrigger` (and potentially `undoTrigger`/`redoTrigger`) could simplify once the camera is an environment-injected observable — the toolbar could call camera methods directly instead of firing UUID bindings through `ContentView`.
 
 Related coordinate-space subtlety to watch: `PinchGestureView` reports its centroid in installer-local coordinates; `TwoFingerPanView` uses `recognizer.view` (the hosting ancestor). These coincide today because the installer is mounted as a `.background` of the canvas ZStack, but would drift if the canvas becomes inset. Prefer installer-local coordinates for any new recognizer that reports points.
 
@@ -229,16 +235,15 @@ Lightweight root view that routes between the landing screen and the canvas.
 
 ### Performance Considerations
 
-**Current Approach (MVP):**
-- All placed items rendered every frame
-- No spatial indexing or visibility culling
-- Acceptable for small boards (<100 items)
+**Current Approach:**
+- `visibleImages: [PlacedImage]` is a culled subset of `placedImages` — only images whose world rects intersect the current viewport are rendered as `FileImageView` instances
+- `imageRenderPlan()` splits `visibleImages` into `detailItems` (full image) and `overviewItems` (low-detail placeholder rect) based on screen size and LOD thresholds
+- `scheduleRefreshVisibleElements()` re-queries `LocalBoardStore.imagePlacements(in:viewport:)` after a 40ms debounce (80ms during active interaction)
+- Texts (`placedTexts`) are not culled — they are lightweight SwiftUI views with no image-loading cost
 
 **Future Optimization Paths:**
-- Implement visibility culling based on transformed viewport bounds
-- Use `CMTileKey` system (defined in `CanvasModels.swift` by Dev B) for spatial indexing
-- Consider render caching for static content
-- Investigate Metal-based rendering for large item counts
+- Cull text elements by viewport (low priority — texts are cheap)
+- Consider Metal-based rendering for extremely large boards (1000+ images)
 
 ---
 
@@ -333,6 +338,81 @@ NavigationStack {
 `ContentView` no longer hosts a custom overlay layer; the nav bar renders translucent glass over `BoardCanvasView`, which extends edge-to-edge underneath.
 
 **Settings sheet** is still presented from `ContentView` via `.sheet(isPresented: $showingSettings)` when the gear toolbar item fires. See "Canvas Settings Sheet" below.
+
+---
+
+## Canvas Navigation Aids
+
+### Minimap
+
+**Status: Implemented**
+
+**File:** `Features/BoardCanvas/CanvasMinimapView.swift`
+
+A 160×100pt semi-transparent overlay in the bottom-right corner of the canvas that shows where content is relative to the current viewport.
+
+**Architecture:** Pure stateless view — takes `elementRects: [CGRect]` and `viewportRect: CGRect`, recomputed on every body pass.
+
+```swift
+struct CanvasMinimapView: View {
+    let elementRects: [CGRect]
+    let viewportRect: CGRect
+}
+```
+
+`BoardCanvasView` feeds it via:
+```swift
+.overlay(alignment: .bottomTrailing) {
+    let rects = allElementRects()   // placedImages + placedTexts worldRects
+    if !rects.isEmpty {
+        CanvasMinimapView(elementRects: rects, viewportRect: viewportCGRect())
+            .padding(16)
+    }
+}
+```
+
+Hidden when the canvas is empty (overlay is conditional on `!rects.isEmpty`).
+
+**Rendering (SwiftUI `Canvas`):**
+- `worldExtents()` computes the union of all element rects + viewport, expanded by 12% padding — this is the minimap's world frame
+- `project(_:world:into:)` scales any world-space `CGRect` into the minimap's pixel space
+- Element rects rendered as white rounded rectangles (min 2×2pt so tiny elements remain visible)
+- Viewport rendered as a filled `.white.opacity(0.08)` rect + `DesignSystem.Colors.tertiary` stroke
+- `.allowsHitTesting(false)` — decorative only
+- `.accessibilityHidden(true)` — no semantic content for VoiceOver
+
+### Home Button
+
+**Status: Implemented**
+
+**File:** `Features/BoardCanvas/Tools/CanvasNavigationToolbar.swift`, `BoardCanvasView.swift`
+
+A house icon in the undo/redo group of the toolbar that animates the camera to the bounding-box center of all canvas content.
+
+**Trigger pattern:** Same UUID-binding pattern as undo/redo. `ContentView` owns `@State private var homeTrigger: UUID?`; tapping the toolbar button sets it to `UUID()`. `BoardCanvasView` observes it via `.onChange(of: homeTrigger)` and calls `jumpToContentCenter()`, then clears the trigger.
+
+**`jumpToContentCenter(animated: Bool = true)`** (on `BoardCanvasView`):
+1. Guards `canvasSize != .zero, camera.scale > 0`
+2. `guard let bounds = union(of: allElementRects()) else { return }` — no-op on empty canvas
+3. Computes `target = CGSize(width: canvasSize.width/2 - bounds.midX * camera.scale, height: canvasSize.height/2 - bounds.midY * camera.scale)`
+4. If `animated && !reduceMotion`: `.easeInOut(0.4)` animation, `scheduleRefreshVisibleElements()` in the `completion:` block (deferred so images don't pop mid-animation)
+5. Otherwise: instant offset set + immediate refresh
+
+`@Environment(\.accessibilityReduceMotion) private var reduceMotion` is read on `BoardCanvasView` and passed into the animated path.
+
+### Landing Snap
+
+**Status: Implemented**
+
+When a board with content is opened, the viewport automatically centers on the content bounding box instead of defaulting to world origin.
+
+**Timing fix — why `DispatchQueue.main.async`:**
+
+The snap fires from `onChange(of: elementsToLoad)` after `applyElements`. The guard in `jumpToContentCenter` requires `canvasSize != .zero`, but `canvasSize` is set in `BoardCanvasView.onAppear`. In some SwiftUI lifecycle orderings, `ContentView.onAppear` (which sets `elementsToLoad`) fires before `BoardCanvasView.onAppear` — so the guard would trip. Wrapping the `jumpToContentCenter(animated: false)` call in `DispatchQueue.main.async` defers it past the current run-loop drain, guaranteeing all `onAppear` handlers have fired first.
+
+`DispatchQueue.main.async` is intentional here — a bare `Task { }` uses Swift concurrency's cooperative scheduler and does not drain the run loop, so it doesn't carry the same ordering guarantee.
+
+An additional fallback in `onAppear` itself: if elements were already applied before `canvasSize` was available (the inverse race), the snap fires there instead.
 
 ---
 
@@ -1245,7 +1325,7 @@ The duplicate file-loading code that previously existed in `InsertFileControl.sw
 
 **`Task.sleep(nanoseconds:)` (`BoardCanvasView.swift` ~line 1030 in `scheduleRefreshVisibleElements`)** — `references/api.md` rule says use `.sleep(for:)` instead. Pre-existing on `main`.
 
-**Multiple `DispatchQueue.main.async { binding = nil }` patterns (`BoardCanvasView.swift` ~lines 412, 448, 456, 499, 504)** — used to defer-clear trigger / load bindings. `references/swift.md` rule says no GCD; replace with `Task { @MainActor in ... }` or restructure to not need a deferred reset. All pre-existing on `main`.
+**`DispatchQueue.main.async` in trigger-clear patterns (`BoardCanvasView.swift`)** — Several trigger bindings (`undoTrigger`, `redoTrigger`, `homeTrigger`, `externalInsertURLs`) are cleared via `DispatchQueue.main.async`. `references/swift.md` says no GCD. The `elementsToLoad` handler intentionally uses `.main.async` because its run-loop drain guarantee is load-bearing for the landing snap (see "Landing Snap" above). The others are pre-existing and can be migrated to `Task { @MainActor in ... }` in a cleanup PR.
 
 (The text-elements PR introduced one `DispatchQueue.main.async` in `CanvasTextField.swift` for `becomeFirstResponder` — already converted to `Task { @MainActor }` per the rule.)
 

--- a/architecture-frontend.md
+++ b/architecture-frontend.md
@@ -121,9 +121,15 @@ Pinch and two-finger-pan fire simultaneously and both write `offset`. An earlier
 - Consumers (pinch + two-finger pan today) conform their `Coordinator` to `GestureInstallerCoordinator` and expose their recognizer via `installedRecognizer`.
 - Teardown: each bridge's `dismantleUIView(_:coordinator:)` calls `Coordinator.detach()`, which removes the recognizer from its host view, clears target/delegate, and replaces the event closure with a no-op — prevents duplicate recognizers and retention cycles if the canvas remounts (e.g. `RootView` toggling `showCanvas`).
 
-**Flag for future — camera model tipping point:**
+**Camera model tipping point — refactor now due:**
 
-`offset` and `scale` currently live on `BoardCanvasView` as `@State` and are mutated directly from two gesture handlers plus read from several places (`Canvas` grid closure, every visible-image `.position(...)`, `screenToWorld`, marquee/bbox mapping). When a **third** write site appears (e.g. a programmatic "fit to selection" action, or a new gesture bridge), lift both into an `@Observable CanvasCamera` with `zoom(by:around:)` and `pan(by:)` methods. `zoomAnchoredOffset` moves in as an instance method at that point. Do not do this refactor pre-emptively — it's a cross-cutting change and the single-caller benefit today is small.
+`offset` and `scale` currently live on `BoardCanvasView` as `@State`. They now have **four write sites**: pinch gesture, two-finger-pan gesture, home button (`jumpToContentCenter`), and board-load landing snap (`onChange(of: elementsToLoad)`). The original flag said to lift when a third site appeared; that threshold has been crossed.
+
+Target shape: extract an `@Observable class CanvasCamera` (or `@Observable struct` + `@State`) with `zoom(by:around:)`, `pan(by:)`, and `jumpToCenter(of:animated:)` methods. `zoomAnchoredOffset` and `jumpToContentCenter` move in as methods. `viewportCGRect()` and `allElementRects()` stay on the view (they need view-local state like `canvasSize` and `placedImages`), but the camera itself becomes injectable/testable independently.
+
+Downstream: the UUID-trigger pattern for `homeTrigger` (and potentially `undoTrigger`/`redoTrigger`) could simplify once the camera is a shared observable — the toolbar can call `canvasCamera.jumpToCenter()` directly instead of firing a UUID binding through ContentView.
+
+This is a cross-cutting change; do it as a standalone PR before adding more camera-writing features.
 
 Related coordinate-space subtlety to watch: `PinchGestureView` reports its centroid in installer-local coordinates; `TwoFingerPanView` uses `recognizer.view` (the hosting ancestor). These coincide today because the installer is mounted as a `.background` of the canvas ZStack, but would drift if the canvas becomes inset. Prefer installer-local coordinates for any new recognizer that reports points.
 


### PR DESCRIPTION
## Summary

- **Minimap** — 160×100pt semi-transparent overlay (bottom-right) showing all canvas elements as scaled white rectangles and current viewport as a blue rectangle. Live-updates on pan/zoom. Decorative-only (no hit testing, accessibility hidden).
- **Home button** — house icon in the toolbar that eases the camera to the center of all content. No-op on empty canvases. Snaps instantly when Reduce Motion is enabled.
- **Landing snap** — when opening a saved board, the viewport automatically centers on content instead of dropping at world origin. Uses `DispatchQueue.main.async` deferral to guarantee `canvasSize` is set before centering (timing-safe across both possible `onAppear` orderings between `ContentView` and `BoardCanvasView`).
- **`@Observable CanvasCamera`** — `offset` and `scale` lifted out of `BoardCanvasView` into a dedicated model. Resolves the 4-write-site concern noted in `architecture-frontend.md`. No behavior change — purely architectural.
- **SwiftUI Pro review fixes** — `@MainActor` on `CanvasCamera`, `Task.sleep(for:)` modernization, trigger-clearing paths use `Task { @MainActor in }`, `.accessibilityAddTraits(.isButton)` on canvas element taps, redundant `import UIKit` removed.
- **Body extraction** — grid background, LOD overview layer, and empty-canvas hint extracted from `BoardCanvasView.body` into dedicated `View` structs (`CanvasGridView`, `CanvasOverviewLayer`, `EmptyCanvasOverlay`).

## Test plan

- [ ] Open a saved board — viewport should land centered on content
- [ ] Press home button — camera eases to content center; images outside the prior viewport appear after landing
- [ ] Enable Reduce Motion (Settings → Accessibility) — home button should snap instantly
- [ ] Minimap visible in bottom-right on any board with content; disappears on empty canvas
- [ ] Minimap viewport rectangle tracks pan/zoom in real time
- [ ] Undo/redo, autosave, back navigation unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)